### PR TITLE
MQTT topic_prefix and sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,11 +319,29 @@ ESP_LOGW(TAG, "warning");
 > Note: use `set_global_log_level()` and `set_log_level` in `LogComponent` to adjust the global and 
 tag-specific log levels, respectively.
 
-### Friendly Names with non-ASCII characters
+### Setting custom MQTT topics
 
-Home Assistant discovery only allows entity ids with lower/upper case [a-z] and numbers. If you want to use the
-discovery with other characters in the friendly name, you will have to call `set_custom_entity_id()` with the
-ASCII name for the corresponding `MQTTComponent`.  
+If esphomelib's default MQTT topics don't suit your needs, you can override them. For this, there are two options: 
+
+#### 1. Set the global MQTT topic prefix.
+
+By default, all MQTT topics are named with the application name (see `set_name()`), for example `livingroom/...`.
+However, if you want to use your own MQTT topic prefixes like `home/livingroom/node1/...`, this is possible:
+
+```cpp
+auto *mqtt = app.init_mqtt(...);
+mqtt->set_topic_prefix("home/livingroom/node1");
+```
+
+#### 2. Customize the MQTT topics of a MQTTComponent
+ 
+Customizing the MQTT state/command topics of a single MQTTComponent is also possible. Simple call the 
+`set_custom_*_topic()` on your MQTTComponent like this:
+
+```cpp
+auto dht = app.make_dht_component(12, "Livingroom Temperature", "Livingroom Humidity");
+dht.mqtt_temperature->set_custom_state_topic("home/livingroom/node1/temperature/state");
+```
 
 ### OTA Updates
 

--- a/README.md
+++ b/README.md
@@ -291,11 +291,11 @@ wifi->set_manual_ip(ManualIP{
 
 ### Disable MQTT Logging
 
-The second argument to `init_log()` denotes the MQTT topic that logs will be written to, leaving this empty disables 
-MQTT Logging.
+The second argument to `init_log()` denotes the MQTT topic that logs will be written to, providing a disabled Optional
+disables MQTT Logging.
 
 ```cpp
-app.init_log(115200, "");
+app.init_log(115200, Optional());
 ```
 
 ### Logging
@@ -310,10 +310,10 @@ To use this in your own code, simply include `esp_log.h`, define a TAG, and use 
 static const char *TAG = "main";
 
 // in your code:
-ESP_LOGV(TAG, "verbose");
-ESP_LOGD(TAG, "debug");
-ESP_LOGI(TAG, "information");
-ESP_LOGW(TAG, "warning");
+ESP_LOGV(TAG, "This is a verbose message.");
+ESP_LOGD(TAG, "This is a debug message.");
+ESP_LOGI(TAG, "This is an informational message.");
+ESP_LOGW(TAG, "This is a warning message.");
 ``` 
 
 > Note: use `set_global_log_level()` and `set_log_level` in `LogComponent` to adjust the global and 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ ESP_LOGW(TAG, "This is a warning message.");
 > Note: use `set_global_log_level()` and `set_log_level` in `LogComponent` to adjust the global and 
 tag-specific log levels, respectively.
 
+When using the `platformio device monitor [...]` command, try adding the `--raw` argument - this will apply color to
+log messages in your terminal.
+
 ### Setting custom MQTT topics
 
 If esphomelib's default MQTT topics don't suit your needs, you can override them. For this, there are two options: 
@@ -352,3 +355,16 @@ Then do the upload as you would do normally via serial. You might want to [set a
 > Note: OTA is, by default, enabled without any authentication. If you're on a public WiFi network, it's highly
 > encouraged to set a paraphrase using the `set_auth_*()` methods on the object returned by `init_ota()`. Then also
 > include `upload_flags = -a `*`PASSPHRASE`* in your `platformio.ini`.
+
+### Help! I'm getting lots of `PubSubClient::publish() failed` warnings.
+
+This due to this libraries MQTT client library ([PubSubClient](https://github.com/knolleary/pubsubclient)) having a
+fixed-sized buffer for all MQTT messages. And if your messages are very long, they may not fit inside the buffer, so
+PubSubClient won't send the message. To fix this, increase the buffer size, by adding this to your `platformio.ini`:
+
+```ini
+build_flags =
+    -DMQTT_MAX_PACKET_SIZE=1024
+```
+
+Increase the number if it still doesn't fit.

--- a/src/esphomelib/application.cpp
+++ b/src/esphomelib/application.cpp
@@ -270,4 +270,14 @@ Application::SimpleGPIOSwitchStruct Application::make_simple_gpio_switch(uint8_t
   };
 }
 
+const std::string &Application::get_name() const {
+  return this->name_;
+}
+
+Application::Application() {
+  global_application = this;
+}
+
+Application *global_application;
+
 } // namespace esphomelib

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -38,6 +38,8 @@ namespace esphomelib {
  */
 class Application {
  public:
+  Application();
+
   /** Set the name of the item that is running this app.
    *
    * Note: This will automatically be converted to lowercase_underscore.
@@ -306,6 +308,9 @@ class Application {
   /// Assert that name has been set.
   void assert_name() const;
 
+  /// Get the name of this Application set by set_name().
+  const std::string &get_name() const;
+
  protected:
   std::vector<Component *> components_;
   mqtt::MQTTClientComponent *mqtt_client_;
@@ -313,6 +318,9 @@ class Application {
 
   std::string name_;
 };
+
+/// Global storage of Application pointer - only one Application can exist.
+extern Application *global_application;
 
 template<class C>
 C *Application::register_component(C *c) {

--- a/src/esphomelib/component.h
+++ b/src/esphomelib/component.h
@@ -87,10 +87,6 @@ class Component {
   /** Internal loop() function.
    *
    * Basically, it handles stuff like interval/timeout functions and eventually calls loop().
-   *
-   * @see SetInterval()
-   * @see SetTimeout()
-   * @see loop()
    */
   void loop_();
   void setup_();

--- a/src/esphomelib/helpers.cpp
+++ b/src/esphomelib/helpers.cpp
@@ -52,6 +52,14 @@ std::string to_lowercase_underscore(std::string s) {
   return s;
 }
 
+std::string sanitize_string_whitelist(const std::string &s, const std::string &whitelist) {
+  std::string out(s);
+  out.erase(std::remove_if(out.begin(), out.end(), [&out, &whitelist](const char &c) {
+    return whitelist.find(c) == std::string::npos;
+  }), out.end());
+  return out;
+}
+
 ExponentialMovingAverage::ExponentialMovingAverage(float alpha) : alpha_(alpha), accumulator_(0) {}
 
 float ExponentialMovingAverage::get_alpha() const {

--- a/src/esphomelib/helpers.cpp
+++ b/src/esphomelib/helpers.cpp
@@ -60,6 +60,17 @@ std::string sanitize_string_whitelist(const std::string &s, const std::string &w
   return out;
 }
 
+std::string sanitize_hostname(const std::string &hostname) {
+  std::string s = sanitize_string_whitelist(hostname, HOSTNAME_CHARACTER_WHITELIST);
+  return truncate_string(s, 63);
+}
+
+std::string truncate_string(const std::string &s, size_t length) {
+  if (s.length() > length)
+    return s.substr(0, length);
+  return s;
+}
+
 ExponentialMovingAverage::ExponentialMovingAverage(float alpha) : alpha_(alpha), accumulator_(0) {}
 
 float ExponentialMovingAverage::get_alpha() const {

--- a/src/esphomelib/helpers.h
+++ b/src/esphomelib/helpers.h
@@ -69,6 +69,9 @@ float gamma_correct(float value, float gamma);
 template<typename T>
 std::string value_to_hex_string(T value);
 
+/// Sanitizes the input string with the whitelist.
+std::string sanitize_string_whitelist(const std::string &s, const std::string &whitelist);
+
 /// Helper class to represent an optional value.
 template<typename T>
 struct Optional {

--- a/src/esphomelib/helpers.h
+++ b/src/esphomelib/helpers.h
@@ -22,6 +22,14 @@ std::string get_mac_address();
 /// Constructs a hostname by concatenating base, a hyphen, and the MAC address.
 std::string generate_hostname(const std::string &base);
 
+const std::string HOSTNAME_CHARACTER_WHITELIST = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+
+/// Sanitize the hostname by removing characters that are not in the whitelist and truncating it to 63 chars.
+std::string sanitize_hostname(const std::string &hostname);
+
+/// Truncate a string to a specific length
+std::string truncate_string(const std::string &s, size_t length);
+
 /// Checks whether the provided IPAddress is empty (is 0.0.0.0).
 bool is_empty(const IPAddress &address);
 

--- a/src/esphomelib/light/light_state.cpp
+++ b/src/esphomelib/light/light_state.cpp
@@ -33,9 +33,10 @@ void LightState::start_flash(const LightColorValues &target, uint32_t length) {
   if (length <= 0)
     return;
 
-  LightColorValues end_colors = this->get_remote_values();
-  this->transformer_ = make_unique<LightFlashTransformer>(millis(), length, end_colors,
-                                                          target);
+  LightColorValues end_colors = this->values_;
+  if (this->transformer_ != nullptr)
+    end_colors = this->transformer_->get_end_values();
+  this->transformer_ = make_unique<LightFlashTransformer>(millis(), length, end_colors, target);
   this->send_values();
 }
 

--- a/src/esphomelib/log_component.cpp
+++ b/src/esphomelib/log_component.cpp
@@ -21,7 +21,7 @@ int LogComponent::log_vprintf_(const char *format, va_list args) {
       Serial.print(log->tx_buffer_.data());
     }
 
-    if (log->mqtt_logging_enabled_ && mqtt::global_mqtt_client != nullptr)
+    if (log->mqtt_logging_enabled_ && mqtt::global_mqtt_client != nullptr && mqtt::global_mqtt_client->is_connected())
       mqtt::global_mqtt_client->publish(log->get_logging_topic(), log->tx_buffer_.data(), true);
   }
 
@@ -45,7 +45,6 @@ void LogComponent::pre_setup() {
 #endif
 
   ESP_LOGI(TAG, "Log initialized");
-  Serial.println("Log initialized (Serial)");
 }
 uint32_t LogComponent::get_baud_rate() const {
   return this->baud_rate_;
@@ -75,8 +74,8 @@ bool LogComponent::is_mqtt_logging_enabled() const {
 void LogComponent::set_mqtt_logging_enabled(bool mqtt_logging_enabled) {
   this->mqtt_logging_enabled_ = mqtt_logging_enabled;
 }
-const std::string &LogComponent::get_logging_topic() {
-  if (this->mqtt_logging_topic_.empty())
+std::string LogComponent::get_logging_topic() {
+  if (this->mqtt_logging_topic_.empty() && mqtt::global_mqtt_client != nullptr)
     return mqtt::global_mqtt_client->get_topic_prefix() + "/debug";
   return this->mqtt_logging_topic_;
 }

--- a/src/esphomelib/log_component.cpp
+++ b/src/esphomelib/log_component.cpp
@@ -6,6 +6,7 @@
 #include <HardwareSerial.h>
 #include "log_component.h"
 #include "esphomelib/mqtt/mqtt_client_component.h"
+#include "application.h"
 
 namespace esphomelib {
 
@@ -20,15 +21,15 @@ int LogComponent::log_vprintf_(const char *format, va_list args) {
       Serial.print(log->tx_buffer_.data());
     }
 
-    if (!log->mqtt_topic_.empty() && mqtt::global_mqtt_client != nullptr)
-      mqtt::global_mqtt_client->publish(log->mqtt_topic_, log->tx_buffer_.data(), true);
+    if (log->mqtt_logging_enabled_ && mqtt::global_mqtt_client != nullptr)
+      mqtt::global_mqtt_client->publish(log->get_logging_topic(), log->tx_buffer_.data(), true);
   }
 
   return ret;
 }
 
-LogComponent::LogComponent(uint32_t baud_rate, std::string mqtt_topic, size_t tx_buffer_size)
-    : baud_rate_(baud_rate), mqtt_topic_(std::move(mqtt_topic)) {
+LogComponent::LogComponent(uint32_t baud_rate, size_t tx_buffer_size)
+    : baud_rate_(baud_rate),  mqtt_logging_enabled_(true) {
   this->set_tx_buffer_size(tx_buffer_size);
 }
 
@@ -52,12 +53,6 @@ uint32_t LogComponent::get_baud_rate() const {
 void LogComponent::set_baud_rate(uint32_t baud_rate) {
   this->baud_rate_ = baud_rate;
 }
-const std::string &LogComponent::get_mqtt_topic() const {
-  return this->mqtt_topic_;
-}
-void LogComponent::set_mqtt_topic(const std::string &mqtt_topic) {
-  this->mqtt_topic_ = mqtt_topic;
-}
 void LogComponent::set_global_log_level(esp_log_level_t log_level) {
   this->set_log_level("*", log_level);
 }
@@ -69,6 +64,21 @@ size_t LogComponent::get_tx_buffer_size() const {
 }
 void LogComponent::set_tx_buffer_size(size_t tx_buffer_size) {
   this->tx_buffer_.reserve(tx_buffer_size);
+}
+void LogComponent::set_custom_logging_topic(const std::string &custom_logging_topic) {
+  this->mqtt_logging_topic_ = custom_logging_topic;
+  this->set_mqtt_logging_enabled(true);
+}
+bool LogComponent::is_mqtt_logging_enabled() const {
+  return this->mqtt_logging_enabled_;
+}
+void LogComponent::set_mqtt_logging_enabled(bool mqtt_logging_enabled) {
+  this->mqtt_logging_enabled_ = mqtt_logging_enabled;
+}
+const std::string &LogComponent::get_logging_topic() {
+  if (this->mqtt_logging_topic_.empty())
+    return mqtt::global_mqtt_client->get_topic_prefix() + "/debug";
+  return this->mqtt_logging_topic_;
 }
 
 LogComponent *global_log_component = nullptr;

--- a/src/esphomelib/log_component.h
+++ b/src/esphomelib/log_component.h
@@ -44,7 +44,7 @@ class LogComponent : public Component {
   void set_custom_logging_topic(const std::string &custom_logging_topic);
 
   /// Return the logging topic, opting for the default if it hasn't been customized.
-  const std::string &get_logging_topic();
+  std::string get_logging_topic();
 
   /// Whether logging to MQTT is enabled.
   bool is_mqtt_logging_enabled() const;

--- a/src/esphomelib/log_component.h
+++ b/src/esphomelib/log_component.h
@@ -11,9 +11,11 @@
 #include <utility>
 #include <vector>
 #include "component.h"
+#include "mqtt/mqtt_component.h"
 #include <esp_log.h>
 #include <cassert>
 #include "esp32-hal-log.h"
+#include "helpers.h"
 
 namespace esphomelib {
 
@@ -30,15 +32,25 @@ class LogComponent : public Component {
    * @param mqtt_topic The topic to push MQTT logs to. Empty string to disable MQTT logging.
    * @param tx_buffer_size The buffer size (in bytes) used for constructing log messages.
    */
-  explicit LogComponent(uint32_t baud_rate = 11520, std::string mqtt_topic = "", size_t tx_buffer_size = 512);
+  explicit LogComponent(uint32_t baud_rate = 11520, size_t tx_buffer_size = 512);
 
   /// Set up this component.
   void pre_setup();
 
   uint32_t get_baud_rate() const;
   void set_baud_rate(uint32_t baud_rate);
-  const std::string &get_mqtt_topic() const;
-  void set_mqtt_topic(const std::string &mqtt_topic);
+
+  /// Set a custom MQTT logging topic. Set to "" for default behavior. This will also enable logging.
+  void set_custom_logging_topic(const std::string &custom_logging_topic);
+
+  /// Return the logging topic, opting for the default if it hasn't been customized.
+  const std::string &get_logging_topic();
+
+  /// Whether logging to MQTT is enabled.
+  bool is_mqtt_logging_enabled() const;
+  /// Enable/Disable logging to MQTT
+  void set_mqtt_logging_enabled(bool mqtt_logging_enabled);
+
   size_t get_tx_buffer_size() const;
   void set_tx_buffer_size(size_t tx_buffer_size);
   /// Set the global log level.
@@ -51,7 +63,8 @@ class LogComponent : public Component {
 
   uint32_t baud_rate_;
   std::vector<char> tx_buffer_;
-  std::string mqtt_topic_;
+  std::string mqtt_logging_topic_;
+  bool mqtt_logging_enabled_;
 };
 
 void __assert_func(const char *file, int lineno, const char *func, const char *exp);

--- a/src/esphomelib/mqtt/mqtt_client_component.cpp
+++ b/src/esphomelib/mqtt/mqtt_client_component.cpp
@@ -18,7 +18,7 @@ MQTTClientComponent::MQTTClientComponent(MQTTCredentials credentials,
                                          std::string node_id)
     : credentials_(std::move(credentials)),
       discovery_info_(Optional<MQTTDiscoveryInfo>()),
-      node_id_(std::move(node_id)) {
+      topic_prefix_(std::move(node_id)) {
 
 }
 
@@ -191,11 +191,11 @@ float MQTTClientComponent::get_setup_priority() const {
 const Optional<MQTTDiscoveryInfo> &MQTTClientComponent::get_discovery_info() const {
   return this->discovery_info_;
 }
-void MQTTClientComponent::set_node_id(const std::string &node_id) {
-  this->node_id_ = node_id;
+void MQTTClientComponent::set_topic_prefix(const std::string &topic_prefix) {
+  this->topic_prefix_ = topic_prefix;
 }
-const std::string &MQTTClientComponent::get_node_id() const {
-  return this->node_id_;
+const std::string &MQTTClientComponent::get_topic_prefix() const {
+  return this->topic_prefix_;
 }
 const Optional<MQTTMessage> &MQTTClientComponent::get_birth_message() const {
   return this->birth_message_;

--- a/src/esphomelib/mqtt/mqtt_client_component.cpp
+++ b/src/esphomelib/mqtt/mqtt_client_component.cpp
@@ -30,6 +30,7 @@ void MQTTClientComponent::setup() {
   ESP_LOGV(TAG, "    Server Address: %s:%u", this->credentials_.address.c_str(), this->credentials_.port);
   ESP_LOGV(TAG, "    Username: '%s'", this->credentials_.username.c_str());
   ESP_LOGV(TAG, "    Password: '%s'", this->credentials_.password.c_str());
+  this->credentials_.client_id = truncate_string(this->credentials_.client_id, 23);
   ESP_LOGV(TAG, "    Client ID: '%s'", this->credentials_.client_id.c_str());
   this->mqtt_client_.setCallback(pub_sub_client_callback);
 

--- a/src/esphomelib/mqtt/mqtt_client_component.h
+++ b/src/esphomelib/mqtt/mqtt_client_component.h
@@ -52,7 +52,7 @@ struct MQTTCredentials {
   uint16_t port; ///< The port number of the server.
   std::string username;
   std::string password;
-  std::string client_id;
+  std::string client_id; ///< The client ID. Will automatically be truncated to 23 characters.
 };
 
 /** internal struct for MQTT Home Assistant discovery

--- a/src/esphomelib/mqtt/mqtt_client_component.h
+++ b/src/esphomelib/mqtt/mqtt_client_component.h
@@ -107,13 +107,17 @@ class MQTTClientComponent : public Component {
   /// Globally disable Home Assistant discovery.
   void disable_discovery();
 
-  /** Set the node_id used for creating state and command topics.
+  /** Set the topic prefix that will be prepended to all topics together with "/". This will, in most cases,
+   * be the name of your Application.
    *
-   * @param node_id The node_id, should be lower case and without spaces.
+   * For example, if "livingroom" is passed to this method, all state topics will, by default, look like
+   * "livingroom/.../state"
+   *
+   * @param topic_prefix The topic prefix. The last "/" is appended automatically.
    */
-  void set_node_id(const std::string &node_id);
-  /// Get the node_id of this device.
-  const std::string &get_node_id() const;
+  void set_topic_prefix(const std::string &topic_prefix);
+  /// Get the topic prefix of this device.
+  const std::string &get_topic_prefix() const;
 
   /** Subscribe to an MQTT topic and call callback when a message is received.
    *
@@ -170,7 +174,7 @@ class MQTTClientComponent : public Component {
   Optional<MQTTMessage> last_will_;
   Optional<MQTTMessage> birth_message_;
   Optional<MQTTDiscoveryInfo> discovery_info_;
-  std::string node_id_;
+  std::string topic_prefix_;
 
   std::vector<MQTTSubscription> subscriptions_;
   PubSubClient mqtt_client_;

--- a/src/esphomelib/mqtt/mqtt_client_component.h
+++ b/src/esphomelib/mqtt/mqtt_client_component.h
@@ -93,6 +93,15 @@ class MQTTClientComponent : public Component {
   void remove_birth_message();
   const Optional<MQTTMessage> &get_birth_message() const;
 
+  /// Getter for use_status_messages.
+  bool get_use_status_messages() const;
+  /// Set whether this client will automatically send topic_prefix/status on connect/disconnect.
+  /// This will also make all MQTTComponents use Home Assistant availability_topic feature.
+  void set_use_status_messages(bool use_status_messages);
+
+  /// Get the status message topic esphomelib will use by default if use_status_messages is enabled.
+  std::string get_default_status_message_topic() const;
+
   /** Set the Home Assistant discovery info
    *
    * See <a href="https://home-assistant.io/docs/mqtt/discovery/">MQTT Discovery</a>.
@@ -171,7 +180,11 @@ class MQTTClientComponent : public Component {
   void reconnect();
 
   MQTTCredentials credentials_;
+  /// The last will message. Disabled optional denotes it being disabled and
+  /// an empty topic denotes the default value being used.
   Optional<MQTTMessage> last_will_;
+  /// The birth message (e.g. the message that's send on an established connection.
+  /// See last_will_ for what different values denote.
   Optional<MQTTMessage> birth_message_;
   Optional<MQTTDiscoveryInfo> discovery_info_;
   std::string topic_prefix_;
@@ -179,6 +192,7 @@ class MQTTClientComponent : public Component {
   std::vector<MQTTSubscription> subscriptions_;
   PubSubClient mqtt_client_;
   WiFiClient client_;
+  bool use_status_messages_;
 };
 
 extern MQTTClientComponent *global_mqtt_client;

--- a/src/esphomelib/mqtt/mqtt_component.cpp
+++ b/src/esphomelib/mqtt/mqtt_component.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <utility>
 #include <esp_log.h>
+#include <esphomelib/helpers.h>
+#include <esphomelib/application.h>
 
 namespace esphomelib {
 
@@ -22,12 +24,13 @@ std::string MQTTComponent::get_discovery_topic() const {
   const auto &discovery = global_mqtt_client->get_discovery_info();
   if (!discovery)
     return "";
-  return discovery->prefix + "/" + this->component_type() + "/" + global_mqtt_client->get_node_id() +
-      "/" + this->get_entity_id() + "/config";
+  std::string sanitized_name = sanitize_string_whitelist(global_application->get_name(), DISCOVERY_CHARACTER_WHITELIST);
+  return discovery->prefix + "/" + this->component_type() + "/" + sanitized_name + "/" + this->get_entity_id()
+      + "/config";
 }
 
 std::string MQTTComponent::get_default_topic_for(const std::string &suffix) const {
-  return global_mqtt_client->get_node_id() + "/" + this->component_type() + "/" + this->get_entity_id() + "/"
+  return global_mqtt_client->get_topic_prefix() + "/" + this->component_type() + "/" + this->get_entity_id() + "/"
       + suffix;
 }
 
@@ -96,7 +99,7 @@ bool MQTTComponent::is_discovery_enabled() const {
 }
 
 std::string MQTTComponent::get_default_entity_id() const {
-  return to_lowercase_underscore(this->friendly_name_);
+  return sanitize_string_whitelist(to_lowercase_underscore(this->friendly_name_), DISCOVERY_CHARACTER_WHITELIST);
 }
 
 const std::string &MQTTComponent::get_friendly_name() const {

--- a/src/esphomelib/mqtt/mqtt_component.cpp
+++ b/src/esphomelib/mqtt/mqtt_component.cpp
@@ -44,7 +44,7 @@ const std::string MQTTComponent::get_command_topic() const {
 
 void MQTTComponent::send_message(const std::string &topic, const std::string &payload, const Optional<bool> &retain) {
   bool actual_retain = this->retain_;
-  if (retain.defined)
+  if (retain)
     actual_retain = retain.value;
   global_mqtt_client->publish(topic, payload, actual_retain);
 }
@@ -64,7 +64,7 @@ void MQTTComponent::send_discovery(const json_build_t &f,
                                    bool state_topic, bool command_topic, const std::string &platform) {
   if (!this->is_discovery_enabled())
     return;
-  if (!global_mqtt_client->get_discovery_info().defined)
+  if (!global_mqtt_client->get_discovery_info())
     return;
   if (this->friendly_name_.empty()) // empty friendly name => no discovery
     return;

--- a/src/esphomelib/mqtt/mqtt_component.h
+++ b/src/esphomelib/mqtt/mqtt_component.h
@@ -25,7 +25,7 @@ struct Availability {
 
 /// All discovery friendly names and node_ids use this whitelist to match the Home Assistant
 /// <a href="https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mqtt/discovery.py#L21">regex</a>.
-const std::string DISCOVERY_CHARACTER_WHITELIST = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+const std::string DISCOVERY_CHARACTER_WHITELIST = HOSTNAME_CHARACTER_WHITELIST;
 
 /** MQTTComponent is the base class for all components that interact with MQTT to expose
  * certain functionality or data from actuators or sensors to clients.

--- a/src/esphomelib/mqtt/mqtt_component.h
+++ b/src/esphomelib/mqtt/mqtt_component.h
@@ -102,6 +102,8 @@ class MQTTComponent : public Component {
   /// Get the MQTT topic for listening to commands.
   const std::string get_command_topic() const;
 
+  /// Get the MQTT topic for a specific suffix/key, if a custom topic has been defined, that one will be used.
+  /// Otherwise, one will be generated with get_default_topic_for().
   const std::string get_topic_for(const std::string &key) const;
 
   /** Send discovery info.

--- a/src/esphomelib/mqtt/mqtt_component.h
+++ b/src/esphomelib/mqtt/mqtt_component.h
@@ -23,6 +23,10 @@ struct Availability {
   std::string payload_not_available;
 };
 
+/// All discovery friendly names and node_ids use this whitelist to match the Home Assistant
+/// <a href="https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/mqtt/discovery.py#L21">regex</a>.
+const std::string DISCOVERY_CHARACTER_WHITELIST = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+
 /** MQTTComponent is the base class for all components that interact with MQTT to expose
  * certain functionality or data from actuators or sensors to clients.
  *

--- a/src/esphomelib/output/ledc_output_component.cpp
+++ b/src/esphomelib/output/ledc_output_component.cpp
@@ -23,8 +23,6 @@ void LEDCOutputComponent::write_value_f(float adjusted_value) {
   if (duty_non_inverted > 0)
     this->enable_atx();
 
-  ESP_LOGV(TAG, "Setting duty %u on channel %u", duty, this->channel_);
-
   ledcWrite(this->channel_, duty);
 }
 

--- a/src/esphomelib/wifi_component.cpp
+++ b/src/esphomelib/wifi_component.cpp
@@ -87,8 +87,8 @@ void WiFiComponent::on_wifi_event(WiFiEvent_t event) {
   ESP_LOGV(TAG, "[WiFi event] %s (%d)", event_name.c_str(), event);
 }
 
-void WiFiComponent::set_hostname(std::string hostname) {
-  this->hostname_ = std::move(hostname);
+void WiFiComponent::set_hostname(const std::string &hostname) {
+  this->hostname_ = sanitize_hostname(hostname);
 }
 
 void WiFiComponent::set_manual_ip(Optional<ManualIP> manual_ip) {

--- a/src/esphomelib/wifi_component.h
+++ b/src/esphomelib/wifi_component.h
@@ -34,7 +34,8 @@ class WiFiComponent : public Component {
    */
   WiFiComponent(std::string ssid, std::string password, std::string hostname);
 
-  void set_hostname(std::string hostname);
+  /// Set the hostname, automatically sanitizes it.
+  void set_hostname(const std::string &hostname);
   const std::string &get_hostname() const;
 
   /// Manually set a static IP for this WiFi interface.


### PR DESCRIPTION
This PR allows users to specify a topic_prefix for MQTT, so that prefixes like `home/livingroom/...` can be used. Additionally, lots of sanitization is now done throughout the library for hostnames, discovery, etc. and the documentation is updated to reflect the changes.