### PR TITLE
OTA Safe Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# esphomelib [![Build Status](https://travis-ci.org/OttoWinter/esphomelib.svg?branch=master)](https://travis-ci.org/OttoWinter/esphomelib)
+A# esphomelib [![Build Status](https://travis-ci.org/OttoWinter/esphomelib.svg?branch=master)](https://travis-ci.org/OttoWinter/esphomelib)
 
 **esphomelib** is a library designed to greatly simplify your firmware code for ESP32/ESP8266-based devices with full 
 seamless Home Assistant integration (with automatic MQTT discovery!) so that you can focus on creating the hardware, 
@@ -13,28 +13,26 @@ For example, the software for a device with an RGB light using the internal PWM 
 
 using namespace esphomelib;
 
-Application app;
-
 void setup() {
-    app.set_name("livingroom");
-    app.init_log();
+    App.set_name("livingroom");
+    App.init_log();
 
-    app.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
-    app.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
-    app.init_ota();
+    App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+    App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+    App.init_ota()->start_safe_mode();
 
-    auto *red = app.make_ledc_output(32); // on pin 32, only available with ESP32
-    auto *green = app.make_ledc_output(33);
-    auto *blue = app.make_ledc_output(34);
-    app.make_rgb_light("Livingroom Light", red, green, blue);
+    auto *red = App.make_ledc_output(32); // on pin 32, only available with ESP32
+    auto *green = App.make_ledc_output(33);
+    auto *blue = App.make_ledc_output(34);
+    App.make_rgb_light("Livingroom Light", red, green, blue);
     
-    app.make_dht_sensor(12, "Livingroom Temperature", "Livingroom Humidity");
+    App.make_dht_sensor(12, "Livingroom Temperature", "Livingroom Humidity");
 
-    app.setup();
+    App.setup();
 }
 
 void loop() {
-    app.loop();
+    App.loop();
 }
 ```
 
@@ -104,17 +102,15 @@ Finally, create a new source file in the `src/` folder (for example `main.cpp`) 
 
 Before adding all the desired components to your code, there are a few things you need to set up first.
 
-Begin with including the library and setting up the `Application` instance, which will handle all of your components.
+Begin with including the library and setting the C++ namespace.
 
 ```cpp
 #include "esphomelib/application.h"
 
 using namespace esphomelib;
-
-Application app;
 ```
 
-Next, set the name of your node (here "livingroom") with `app.set_name()`. This is required if you plan on using MQTT. 
+Next, set the name of your node (here "livingroom") with `App.set_name()`. This is required if you plan on using MQTT. 
 Then initialize the log so you can debug your code on the serial port with baud rate 115200.
 Additionally, important log messages will also be published on MQTT with the topic `<NAME>/debug`
 (here `livingroom/debug`) by default.
@@ -128,25 +124,25 @@ testaments are sent to `livingroom/state`, and discovery will automatically happ
 
 ```cpp
 void setup() {
-    app.set_name("livingroom");
-    app.init_log();
+    App.set_name("livingroom");
+    App.init_log();
 
-    app.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
-    app.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
-    app.init_ota();
+    App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+    App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+    App.init_ota()->start_safe_mode();
     // ...
 
 ```
 
-Last, all you need to do is add your components. Then call `app.setup()` **at the end of** `setup()` - do the same 
+Last, all you need to do is add your components. Then call `App.setup()` **at the end of** `setup()` - do the same 
 with `loop()`
 
 ```cpp
-    app.setup();
+    App.setup();
 }
 
 void loop() {
-    app.loop();
+    App.loop();
 }
 ```
 
@@ -171,7 +167,7 @@ outputs. For example, to use the internal LEDC PWM peripheral, just use the foll
 component on pin 32:
 
 ```cpp
-auto *red = app.make_ledc_output(32);
+auto *red = App.make_ledc_output(32);
 ```
 
 Aditionnaly, you can use `make_atx()` to automatically switch on a power supply when a channel is switched high.
@@ -180,9 +176,9 @@ Next, use the `make_binary_light()`, `make_monochromatic_light()`, and `make_rgb
 (which will be displayed in Home Assistant) and the channels, to create the light component.
 
 ```cpp
-app.make_rgb_light("Livingroom Light", red, green, blue);
-app.make_monochromatic_light("Table Lamp", table_lamp);
-app.make_binary_light("Livingroom Standing Lamp", standing_lamp);
+App.make_rgb_light("Livingroom Light", red, green, blue);
+App.make_monochromatic_light("Table Lamp", table_lamp);
+App.make_binary_light("Livingroom Standing Lamp", standing_lamp);
 ```
 
 > Lights will automatically store their state in non-volatile memory so that lights can restore the color and 
@@ -206,7 +202,7 @@ To create a simple GPIO switch that can control a high/low device on a pin, just
 pin and friendly name.
 
 ```cpp
-app.make_simple_gpio_switch(32, "Livingroom Dehumidifier");
+App.make_simple_gpio_switch(32, "Livingroom Dehumidifier");
 ```
 
 Another feature esphomelib offers is infrared transmitter support. This way, you can control all devices using remote 
@@ -215,9 +211,9 @@ controls yourself. First, you'll need to find the IR codes of the remote - maybe
 the following code to your needs (and repeat from the second line for each channel):
 
 ```cpp
-auto *ir = app.make_ir_transmitter_component(32); // switch out 32 for your IR pin
+auto *ir = App.make_ir_transmitter_component(32); // switch out 32 for your IR pin
 auto *channel = ir->create_transmitter(SendData::from_panasonic(0x4004, 0x100BCBD).repeat(25)); // use the other functions in SendData for other codes.
-app.make_mqtt_switch_for("Panasonic TV On", channel);
+App.make_mqtt_switch_for("Panasonic TV On", channel);
 ```
 
 That's it.
@@ -229,12 +225,12 @@ with the friendly name of the binary sensor, a [device class](https://home-assis
 and the GPIO pin like this:
 
 ```cpp
-app.make_gpio_binary_sensor(36, "Cabinet Motion", binary_sensor::device_class::MOTION);
+App.make_gpio_binary_sensor(36, "Cabinet Motion", binary_sensor::device_class::MOTION);
 ```
 
 #### Fan
 
-Fans can be created by first calling `app.make_fan("Friendly Name")` and then using the return value
+Fans can be created by first calling `App.make_fan("Friendly Name")` and then using the return value
 to set the output channels. See [`examples/fan-example.cpp`](examples/fan-example.cpp) for an example.
 
 ## Home Assistant Configuration
@@ -314,18 +310,17 @@ The second argument to `init_log()` denotes the MQTT topic that logs will be wri
 disables MQTT Logging.
 
 ```cpp
-app.init_log(115200, Optional<std::string>());
+App.init_log(115200, Optional<std::string>());
 ```
 
 ### Logging
 
 esphomelib features a powerful logging engine that automatically pushes logs to Serial and MQTT.
-To use this in your own code, simply include `esphomelib/log.h`, define a TAG, and use `ESP_LOGx` 
-(from [esp-idf](https://esp-idf.readthedocs.io/en/v2.1.1/api-reference/system/log.html)):
+To use this in your own code, simply define a TAG, and use `ESP_LOGx` 
+(from [esp-idf](https://esp-idf.readthedocs.io/en/v2.1.1/api-reference/system/log.html), this has been back-ported 
+to ESP8266 too):
 
 ```cpp
-#include "esphomelib/log.h"
-
 static const char *TAG = "main";
 
 // in your code:
@@ -360,7 +355,7 @@ mosquitto_sub -h 192.168.178.42 -u USERNAME -P PASSWORD -t livingroom/debug
 
 > Note: use `set_global_log_level()` and `set_log_level` in `LogComponent` to adjust the global and 
 > tag-specific log levels, respectively, for more fine-grained control. But also make sure to update the `build_flags`
-> to a low enough log level because `build_flags` defines which log messages are even included in your app.
+> to a low enough log level because `build_flags` defines which log messages are even included in your App.
 
 When using the `platformio device monitor [...]` command, try adding the `--raw` argument - this will apply color to
 log messages in your terminal.
@@ -375,7 +370,7 @@ By default, all MQTT topics are named with the application name (see `set_name()
 However, if you want to use your own MQTT topic prefixes like `home/livingroom/node1/...`, this is possible:
 
 ```cpp
-auto *mqtt = app.init_mqtt(...);
+auto *mqtt = App.init_mqtt(...);
 mqtt->set_topic_prefix("home/livingroom/node1");
 ```
 
@@ -385,13 +380,13 @@ Customizing the MQTT state/command topics of a single MQTTComponent is also poss
 `set_custom_*_topic()` on your MQTTComponent like this:
 
 ```cpp
-auto dht = app.make_dht_sensor(12, "Livingroom Temperature", "Livingroom Humidity");
+auto dht = App.make_dht_sensor(12, "Livingroom Temperature", "Livingroom Humidity");
 dht.mqtt_temperature->set_custom_state_topic("home/livingroom/node1/temperature/state");
 ```
 
 ### OTA Updates
 
-If you call `app.init_ota()` during `setup()`, esphomelib will continuously listen for over-the-air updates. 
+If you call `App.init_ota()` during `setup()`, esphomelib will continuously listen for over-the-air updates. 
 To push an OTA update to your device, simply add `upload_port = `*`IP_OF_YOUR_ESP`* to your `platform.ini`.
 Then do the upload as you would do normally via serial. You might want to [set a static IP](#static-ips) for your ESP32.
 

--- a/examples/dht-dallas-sensors.cpp
+++ b/examples/dht-dallas-sensors.cpp
@@ -6,33 +6,35 @@
 
 using namespace esphomelib;
 
-Application app;
-
 void setup() {
-  app.set_name("outside");
-  app.init_log();
+  App.set_name("outside");
+  App.init_log();
 
-  auto *wifi = app.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+  auto *wifi = App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
   wifi->set_manual_ip(ManualIP{
       .static_ip = IPAddress(192, 168, 178, 42),
       .gateway = IPAddress(192, 168, 178, 1),
       .subnet = IPAddress(255, 255, 255, 0)
   });
-  app.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
-  app.init_ota();
+  App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+  auto *ota = App.init_ota();
+  ota->set_auth_plaintext_password("PASSWORD"); // set an optional password
+  ota->set_port(3232); // This is the default for ESP32
+  ota->set_hostname("custom-hostname"); // manually set the hostname
+  ota->start_safe_mode();
 
-  auto *dallas = app.make_dallas_component(15);
+  auto *dallas = App.make_dallas_component(15);
 
-  app.make_mqtt_sensor_for(dallas->get_sensor_by_address(0xfe0000031f1eaf29), "Ambient Temperature");
-  app.make_mqtt_sensor_for(dallas->get_sensor_by_address(0x710000031f0e7e28), "Heatpump Temperature");
+  App.make_mqtt_sensor_for(dallas->get_sensor_by_address(0xfe0000031f1eaf29), "Ambient Temperature");
+  App.make_mqtt_sensor_for(dallas->get_sensor_by_address(0x710000031f0e7e28), "Heatpump Temperature");
 
-  app.make_dht_sensor(12, "Outside Temperature", "Outside Humidity");
+  App.make_dht_sensor(12, "Outside Temperature", "Outside Humidity");
 
-  app.make_adc_sensor(13, "Analog Voltage");
+  App.make_adc_sensor(13, "Analog Voltage");
 
-  app.setup();
+  App.setup();
 }
 
 void loop() {
-  app.loop();
+  App.loop();
 }

--- a/examples/fan-example.cpp
+++ b/examples/fan-example.cpp
@@ -6,33 +6,31 @@
 
 using namespace esphomelib;
 
-Application app;
-
 void setup() {
-  app.set_name("livingroom-fan");
-  app.init_log();
+  App.set_name("livingroom-fan");
+  App.init_log();
 
-  app.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
-  app.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
-  app.init_ota();
+  App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+  App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+  App.init_ota()->start_safe_mode();
 
-  auto binary_fan = app.make_fan("Binary Fan");
-  binary_fan.output->set_binary(app.make_gpio_output(32));
+  auto binary_fan = App.make_fan("Binary Fan");
+  binary_fan.output->set_binary(App.make_gpio_output(32));
 
-  auto speed_fan = app.make_fan("Speed Fan");
+  auto speed_fan = App.make_fan("Speed Fan");
   // 0.0 -> off speed
   // 0.33 -> low speed
   // 0.66 -> medium speed
   // 1.0 -> high speed
-  speed_fan.output->set_speed(app.make_ledc_output(33), 0.0, 0.33, 0.66, 1.0);
+  speed_fan.output->set_speed(App.make_ledc_output(33), 0.0, 0.33, 0.66, 1.0);
 
-  auto oscillating_fan = app.make_fan("Oscillating Fan");
-  oscillating_fan.output->set_binary(app.make_gpio_output(34));
-  oscillating_fan.output->set_oscillation(app.make_gpio_output(35));
+  auto oscillating_fan = App.make_fan("Oscillating Fan");
+  oscillating_fan.output->set_binary(App.make_gpio_output(34));
+  oscillating_fan.output->set_oscillation(App.make_gpio_output(35));
 
-  app.setup();
+  App.setup();
 }
 
 void loop() {
-  app.loop();
+  App.loop();
 }

--- a/examples/lights.cpp
+++ b/examples/lights.cpp
@@ -12,38 +12,37 @@ using namespace esphomelib;
 
 static const char *TAG = "main";
 
-Application app;
-
 void setup() {
-  app.set_name("lights");
-  app.init_log();
+  App.set_name("lights");
+  App.init_log();
 
-  app.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
-  app.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
-  auto *ota = app.init_ota();
+  App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+  App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+  auto *ota = App.init_ota();
   // Set a plaintext password, alternatively use an MD5 hash for maximum security (set_auth_password_hash)
   ota->set_auth_plaintext_password("VERY_SECURE");
+  ota->start_safe_mode();
 
   // Define a power supply, this will automatically be switched on when the RGBW lights require power.
-  auto *power_supply = app.make_power_supply(GPIOOutputPin(13, OUTPUT, true)); // on pin 13, output pinMode and inverted.
+  auto *power_supply = App.make_power_supply(GPIOOutputPin(13, OUTPUT, true)); // on pin 13, output pinMode and inverted.
   // alternatively if you don't want to invert the pin, just
-  // auto *power_supply = app.make_power_supply(13);
+  // auto *power_supply = App.make_power_supply(13);
 
   Wire.begin(14, 27, 400000);
-  auto *pca9685 = app.make_pca9685_component(500.0f);
+  auto *pca9685 = App.make_pca9685_component(500.0f);
   auto *red = pca9685->create_channel(0, power_supply, 0.75f); // channel 0, with power supply and 75% power.
   auto *green = pca9685->create_channel(1, power_supply, 1.0f);
   auto *blue = pca9685->create_channel(2, power_supply, 1.0f);
   auto *white = pca9685->create_channel(3, power_supply, 1.0f);
-  app.make_rgbw_light("RGBW Lights", red, green, blue, white);
+  App.make_rgbw_light("RGBW Lights", red, green, blue, white);
 
-  app.make_binary_light("Desk Lamp", app.make_gpio_output(15));
+  App.make_binary_light("Desk Lamp", App.make_gpio_output(15));
 
-  app.make_monochromatic_light("Kitchen Lights", app.make_ledc_output(16)); // supports brightness
+  App.make_monochromatic_light("Kitchen Lights", App.make_ledc_output(16)); // supports brightness
 
-  app.setup();
+  App.setup();
 }
 
 void loop() {
-  app.loop();
+  App.loop();
 }

--- a/examples/livingroom.cpp
+++ b/examples/livingroom.cpp
@@ -6,26 +6,24 @@
 
 using namespace esphomelib;
 
-Application app;
-
 void setup() {
-  app.set_name("livingroom");
-  app.init_log();
+  App.set_name("livingroom");
+  App.init_log();
 
-  app.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
-  app.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
-  app.init_ota();
+  App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+  App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+  App.init_ota()->start_safe_mode();
 
-  auto *red = app.make_ledc_output(32); // on pin 32
-  auto *green = app.make_ledc_output(33);
-  auto *blue = app.make_ledc_output(34);
-  app.make_rgb_light("Livingroom Light", red, green, blue);
+  auto *red = App.make_ledc_output(32); // on pin 32
+  auto *green = App.make_ledc_output(33);
+  auto *blue = App.make_ledc_output(34);
+  App.make_rgb_light("Livingroom Light", red, green, blue);
 
-  app.make_dht_sensor(12, "Livingroom Temperature", "Livingroom Humidity");
+  App.make_dht_sensor(12, "Livingroom Temperature", "Livingroom Humidity");
 
-  app.setup();
+  App.setup();
 }
 
 void loop() {
-  app.loop();
+  App.loop();
 }

--- a/examples/livingroom8266.cpp
+++ b/examples/livingroom8266.cpp
@@ -6,24 +6,22 @@
 
 using namespace esphomelib;
 
-Application app;
-
 void setup() {
-  app.set_name("livingroom");
-  app.init_log();
+  App.set_name("livingroom");
+  App.init_log();
 
-  app.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
-  app.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
-  app.init_ota();
+  App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+  App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+  App.init_ota()->start_safe_mode();
 
-  auto *lamp = app.make_gpio_output(32); // on pin 32
-  app.make_binary_light("Standing Lamp", lamp);
+  auto *lamp = App.make_gpio_output(32); // on pin 32
+  App.make_binary_light("Standing Lamp", lamp);
 
-  app.make_dht_sensor(4, "Livingroom Temperature", "Livingroom Humidity");
+  App.make_dht_sensor(4, "Livingroom Temperature", "Livingroom Humidity");
 
-  app.setup();
+  App.setup();
 }
 
 void loop() {
-  app.loop();
+  App.loop();
 }

--- a/examples/switch-binarysensor.cpp
+++ b/examples/switch-binarysensor.cpp
@@ -7,35 +7,33 @@
 using namespace esphomelib;
 using namespace esphomelib::output::ir;
 
-Application app;
-
 static const char *TAG = "main";
 
 void setup() {
-  app.set_name("ir");
-  app.init_log();
+  App.set_name("ir");
+  App.init_log();
 
-  app.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
-  app.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
-  app.init_ota();
+  App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+  App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+  App.init_ota()->start_safe_mode();
 
-  auto *ir = app.make_ir_transmitter_component(32);
-  app.make_mqtt_switch_for("Panasonic TV On", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x100BCBD).repeat(25)));
-  app.make_mqtt_switch_for("Panasonic TV Off", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x100BCBD)));
-  app.make_mqtt_switch_for("Panasonic TV Mute", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x1004C4D)));
-  app.make_mqtt_switch_for("Panasonic TV Volume Up", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x1000405)));
-  app.make_mqtt_switch_for("Panasonic TV Volume Down", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x1008485)));
-  app.make_mqtt_switch_for("Panasonic TV Program Up", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x1002C2D)));
-  app.make_mqtt_switch_for("Panasonic TV Program Down", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x100ACAD)));
+  auto *ir = App.make_ir_transmitter_component(32);
+  App.make_mqtt_switch_for("Panasonic TV On", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x100BCBD).repeat(25)));
+  App.make_mqtt_switch_for("Panasonic TV Off", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x100BCBD)));
+  App.make_mqtt_switch_for("Panasonic TV Mute", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x1004C4D)));
+  App.make_mqtt_switch_for("Panasonic TV Volume Up", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x1000405)));
+  App.make_mqtt_switch_for("Panasonic TV Volume Down", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x1008485)));
+  App.make_mqtt_switch_for("Panasonic TV Program Up", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x1002C2D)));
+  App.make_mqtt_switch_for("Panasonic TV Program Down", ir->create_transmitter(SendData::from_panasonic(0x4004, 0x100ACAD)));
 
-  app.make_gpio_switch(33, "Dehumidifier");
+  App.make_gpio_switch(33, "Dehumidifier");
   ESP_LOGV(TAG, "Humidifier created.");
 
-  app.make_gpio_binary_sensor(36, "Cabinet Motion", binary_sensor::device_class::MOTION);
+  App.make_gpio_binary_sensor(36, "Cabinet Motion", binary_sensor::device_class::MOTION);
 
-  app.setup();
+  App.setup();
 }
 
 void loop() {
-  app.loop();
+  App.loop();
 }

--- a/library.json
+++ b/library.json
@@ -39,10 +39,8 @@
   ],
   "build": {
     "flags": [
-      "-DLOG_LOCAL_LEVEL=ESP_LOG_VERBOSE",
       "-DMQTT_MAX_PACKET_SIZE=512",
-      "-DCONFIG_ARDUHAL_LOG_COLORS=1",
-      "-DCORE_DEBUG_LEVEL=5"
+      "-DARDUINOJSON_ENABLE_STD_STRING"
     ]
   },
   "license": "GPL-3.0",

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,10 +22,8 @@ lib_deps =
     DallasTemperature
     https://github.com/OttoWinter/PCA9685-Arduino.git
 build_flags =
-    -DLOG_LOCAL_LEVEL=ESP_LOG_VERBOSE
     -DMQTT_MAX_PACKET_SIZE=512
-    -DCONFIG_ARDUHAL_LOG_COLORS=1
-    -DCORE_DEBUG_LEVEL=5
+    -DARDUINOJSON_ENABLE_STD_STRING
 src_filter = +<src>
 
 [env:livingroom]

--- a/src/esphomelib/application.cpp
+++ b/src/esphomelib/application.cpp
@@ -190,7 +190,7 @@ WiFiComponent *Application::get_wifi() const {
 OTAComponent *Application::init_ota() {
   auto *ota = new OTAComponent();
   ota->set_hostname(this->wifi_->get_hostname());
-  this->register_component(ota);
+  return this->register_component(ota);
 }
 Application::LightStruct Application::make_monochromatic_light(const std::string &friendly_name,
                                                                output::FloatOutput *mono) {
@@ -274,9 +274,7 @@ output::GPIOBinaryOutputComponent *Application::make_gpio_output(GPIOOutputPin p
   return this->register_component(new GPIOBinaryOutputComponent(pin));
 }
 
-Application::Application() {
-  global_application = this;
-}
+Application::Application() = default;
 
 #ifdef ARDUINO_ARCH_ESP32
 Application::MakePulseCounter Application::make_pulse_counter_sensor(uint8_t pin,
@@ -302,6 +300,6 @@ Application::MakeADCSensor Application::make_adc_sensor(uint8_t pin,
   };
 }
 
-Application *global_application;
+Application App;
 
 } // namespace esphomelib

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -34,6 +34,7 @@
 #include "esphomelib/binary_sensor/binary_sensor.h"
 #include "esphomelib/sensor/sensor.h"
 #include "esphomelib/ota_component.h"
+#include "esphomelib/log.h"
 
 namespace esphomelib {
 
@@ -375,7 +376,7 @@ class Application {
 };
 
 /// Global storage of Application pointer - only one Application can exist.
-extern Application *global_application;
+extern Application App;
 
 template<class C>
 C *Application::register_component(C *c) {

--- a/src/esphomelib/binary_sensor/mqtt_binary_sensor_component.cpp
+++ b/src/esphomelib/binary_sensor/mqtt_binary_sensor_component.cpp
@@ -19,7 +19,7 @@ std::string MQTTBinarySensorComponent::component_type() const {
 void MQTTBinarySensorComponent::setup() {
   this->send_discovery([&](JsonBuffer &buffer, JsonObject &root) {
     if (!this->device_class_.empty())
-      root["device_class"] = buffer.strdup(this->get_device_class().c_str());
+      root["device_class"] = this->get_device_class();
   }, true, false);
 }
 

--- a/src/esphomelib/component.cpp
+++ b/src/esphomelib/component.cpp
@@ -96,9 +96,6 @@ bool Component::cancel_time_function(const std::string &name, TimeFunction::Type
   }
   return false;
 }
-Component::Component() : component_state_(CONSTRUCTION) {
-
-}
 void Component::setup_() {
   assert_construction_state(this);
   this->component_state_ = SETUP;

--- a/src/esphomelib/component.h
+++ b/src/esphomelib/component.h
@@ -50,9 +50,11 @@ const float MQTT_COMPONENT = 5.0f; ///< for MQTT component initialization
  */
 class Component {
  public:
-  Component();
-
-  enum ComponentState { CONSTRUCTION, SETUP, LOOP };
+  enum ComponentState {
+    CONSTRUCTION = 0,
+    SETUP = 1,
+    LOOP = 2
+  };
 
   /** Where the component's initialization should happen.
    *
@@ -168,7 +170,7 @@ class Component {
    */
   std::vector<TimeFunction> time_functions_;
 
-  ComponentState component_state_; ///< State of this component.
+  ComponentState component_state_{CONSTRUCTION}; ///< State of this component.
 };
 
 } // namespace esphomelib

--- a/src/esphomelib/fan/mqtt_fan_component.cpp
+++ b/src/esphomelib/fan/mqtt_fan_component.cpp
@@ -30,12 +30,12 @@ void MQTTFanComponent::setup() {
 
   this->send_discovery([&](JsonBuffer &buffer, JsonObject &root) {
     if (this->state_->get_traits().supports_oscillation()) {
-      root["oscillation_command_topic"] = buffer.strdup(this->get_oscillation_command_topic().c_str());
-      root["oscillation_state_topic"] = buffer.strdup(this->get_oscillation_state_topic().c_str());
+      root["oscillation_command_topic"] = this->get_oscillation_command_topic();
+      root["oscillation_state_topic"] = this->get_oscillation_state_topic();
     }
     if (this->state_->get_traits().supports_speed()) {
-      root["speed_command_topic"] = buffer.strdup(this->get_speed_command_topic().c_str());
-      root["speed_state_topic"] = buffer.strdup(this->get_speed_state_topic().c_str());
+      root["speed_command_topic"] = this->get_speed_command_topic();
+      root["speed_state_topic"] = this->get_speed_state_topic();
     }
   });
 

--- a/src/esphomelib/input/dallas_component.cpp
+++ b/src/esphomelib/input/dallas_component.cpp
@@ -110,9 +110,11 @@ DallasTemperatureSensor *DallasComponent::get_sensor_by_index(uint8_t index,
 void DallasComponent::request_temperature(DallasTemperatureSensor *sensor) {
   run_without_interrupts<void>([this, sensor] {
     this->dallas_.requestTemperaturesByAddress(sensor->get_address8());
+    delayMicroseconds(10); // seems to be a lot more stable
   });
 
   this->set_timeout(sensor->get_name(), sensor->millis_to_wait_for_conversion(), [this, sensor] {
+    delayMicroseconds(10); // seems to be a lot more stable
     auto temperature = run_without_interrupts<float>([this, sensor] {
       return this->dallas_.getTempC(sensor->get_address8());
     });

--- a/src/esphomelib/light/mqtt_json_light_component.cpp
+++ b/src/esphomelib/light/mqtt_json_light_component.cpp
@@ -34,7 +34,7 @@ void MQTTJSONLightComponent::setup() {
       for (const LightEffect::Entry &entry : light_effect_entries) {
         if (!this->state_->get_traits().supports_traits(entry.requirements))
           continue;
-        effect_list.add(buffer.strdup(entry.name.c_str()));
+        effect_list.add(entry.name);
       }
     }
   }, true, true, "mqtt_json");
@@ -101,7 +101,7 @@ void MQTTJSONLightComponent::send_light_values() {
   this->send_json_message(this->get_state_topic(), [&](JsonBuffer &buffer, JsonObject &root) {
     assert_not_nullptr(this->state_);
     if (this->state_->supports_effects())
-      root["effect"] = buffer.strdup(this->state_->get_effect_name().c_str());
+      root["effect"] = this->state_->get_effect_name();
     remote_values.dump_json(root, this->state_->get_traits());
   });
 }

--- a/src/esphomelib/log.h
+++ b/src/esphomelib/log.h
@@ -61,7 +61,7 @@ int esp_log_vprintf_(ESPLogLevel level, const std::string &tag, const char *form
 int esp_idf_log_vprintf_(const char *format, va_list args);
 
 #define ESPHOMELIB_SHORT_LOG_FORMAT(tag, letter, format)  ESPHOMELIB_LOG_COLOR_ ## letter format ESPHOMELIB_LOG_RESET_COLOR
-#define ESPHOMELIB_LOG_FORMAT(tag, letter, format)  ESPHOMELIB_LOG_COLOR_ ## letter "[" #letter "][%s:%u in %s]: " format ESPHOMELIB_LOG_RESET_COLOR, __FUNCTION__, __LINE__, tag
+#define ESPHOMELIB_LOG_FORMAT(tag, letter, format)  ESPHOMELIB_LOG_COLOR_ ## letter "[" #letter "][%s:%s:%u]: " format ESPHOMELIB_LOG_RESET_COLOR, tag, __FUNCTION__, __LINE__
 
 #if ESPHOMELIB_LOG_LEVEL >= ESP_LOG_LEVEL_VERBOSE
   #define esph_log_v(tag, format, ...) esp_log_printf_(ESPHOMELIB_LOG_LEVEL_VERBOSE, tag, ESPHOMELIB_LOG_FORMAT(tag, V, format), ##__VA_ARGS__)

--- a/src/esphomelib/mqtt/mqtt_component.cpp
+++ b/src/esphomelib/mqtt/mqtt_component.cpp
@@ -26,7 +26,7 @@ std::string MQTTComponent::get_discovery_topic() const {
   const auto &discovery = global_mqtt_client->get_discovery_info();
   if (!discovery)
     return "";
-  std::string sanitized_name = sanitize_string_whitelist(global_application->get_name(), DISCOVERY_CHARACTER_WHITELIST);
+  std::string sanitized_name = sanitize_string_whitelist(App.get_name(), DISCOVERY_CHARACTER_WHITELIST);
   return discovery->prefix + "/" + this->component_type() + "/" + sanitized_name + "/" + this->get_entity_id()
       + "/config";
 }
@@ -74,20 +74,20 @@ void MQTTComponent::send_discovery(const json_build_t &f,
   ESP_LOGV(TAG, "Sending discovery...");
 
   this->send_json_message(this->get_discovery_topic(), [&](JsonBuffer &buffer, JsonObject &root) {
-    root["name"] = buffer.strdup(this->friendly_name_.c_str());
-    root["platform"] = buffer.strdup(platform.c_str());
+    root["name"] = this->friendly_name_;
+    root["platform"] = platform;
     if (state_topic)
-      root["state_topic"] = buffer.strdup(this->get_state_topic().c_str());
+      root["state_topic"] = this->get_state_topic();
     if (command_topic)
-      root["command_topic"] = buffer.strdup(this->get_command_topic().c_str());
+      root["command_topic"] = this->get_command_topic();
 
     if (this->get_availability()) {
       assert(!this->availability_->topic.empty());
-      root["availability_topic"] = buffer.strdup(this->availability_->topic.c_str());
+      root["availability_topic"] = this->availability_->topic;
       if (this->availability_->payload_available != "online")
-        root["payload_available"] = buffer.strdup(this->availability_->payload_available.c_str());
+        root["payload_available"] = this->availability_->payload_available;
       if (this->availability_->payload_not_available != "offline")
-        root["payload_not_available"] = buffer.strdup(this->availability_->payload_not_available.c_str());
+        root["payload_not_available"] = this->availability_->payload_not_available;
     }
 
     f(buffer, root);

--- a/src/esphomelib/ota_component.cpp
+++ b/src/esphomelib/ota_component.cpp
@@ -7,18 +7,25 @@
 #include <ArduinoOTA.h>
 
 #include "esphomelib/log.h"
+#include "esphomelib/esppreferences.h"
+#include "esphomelib/application.h"
 
 namespace esphomelib {
 
 static const char *TAG = "ota";
+static const char *PREF_TAG = "ota"; ///< Tag for preferences.
+static const char *PREF_SAFE_MODE_COUNTER_KEY = "safe_mode";
 
 void OTAComponent::setup() {
-  ESP_LOGD(TAG, "Setting up OTA...");
+  ESP_LOGCONFIG(TAG, "Setting up OTA...");
+  ESP_LOGCONFIG(TAG, "    port: %u", this->port_);
   this->server_ = new WiFiServer(this->port_);
   this->server_->begin();
 
-  if (!this->hostname_.empty())
+  if (!this->hostname_.empty()) {
+    ESP_LOGCONFIG(TAG, "    hostname: '%s'", this->hostname_.c_str());
     ArduinoOTA.setHostname(this->hostname_.c_str());
+  }
   ArduinoOTA.setPort(this->port_);
   switch (this->auth_type_) {
     case PLAINTEXT: {
@@ -39,6 +46,9 @@ void OTAComponent::setup() {
   ArduinoOTA.onEnd([&]() {
     ESP_LOGI(TAG, "OTA update finished!");
     ESP_LOGI(TAG, "Rebooting...");
+    if (this->has_safe_mode_)
+      // Don't make successful OTAs trigger boot loop detection.
+      global_preferences.put_uint8(PREF_TAG, PREF_SAFE_MODE_COUNTER_KEY, 0);
   });
   ArduinoOTA.onProgress([](uint progress, uint total) {
     float percentage = float(progress) * 100 / float(total);
@@ -77,11 +87,21 @@ void OTAComponent::setup() {
 void OTAComponent::loop() {
   do {
     ArduinoOTA.handle();
+    yield();
   } while (this->ota_triggered_);
+
+  if (this->has_safe_mode_ && (millis() - this->safe_mode_start_time_) > this->safe_mode_enable_time_) {
+    this->has_safe_mode_ = false;
+    // successful boot, reset counter
+    ESP_LOGI(TAG, "Boot seems successful, resetting boot loop counter.");
+    global_preferences.put_uint8(PREF_TAG, PREF_SAFE_MODE_COUNTER_KEY, 0);
+  }
 }
 
 OTAComponent::OTAComponent(uint16_t port, std::string hostname)
-    : port_(port), hostname_(std::move(hostname)), auth_type_(OPEN), server_(nullptr) {}
+    : port_(port), hostname_(std::move(hostname)), auth_type_(OPEN), server_(nullptr) {
+
+}
 
 void OTAComponent::set_auth_open() {
   this->auth_type_ = OPEN;
@@ -98,16 +118,48 @@ float OTAComponent::get_setup_priority() const {
   return setup_priority::MQTT_CLIENT;
 }
 uint16_t OTAComponent::get_port() const {
-  return port_;
+  return this->port_;
 }
 void OTAComponent::set_port(uint16_t port) {
-  port_ = port;
+  this->port_ = port;
 }
 const std::string &OTAComponent::get_hostname() const {
-  return hostname_;
+  return this->hostname_;
 }
 void OTAComponent::set_hostname(const std::string &hostname) {
-  hostname_ = hostname;
+  this->hostname_ = sanitize_hostname(hostname);
+}
+void OTAComponent::start_safe_mode(uint8_t num_attempts, uint32_t enable_time) {
+  this->has_safe_mode_ = true;
+  this->safe_mode_start_time_ = millis();
+  this->safe_mode_enable_time_ = enable_time;
+
+  uint8_t counter = global_preferences.get_uint8(PREF_TAG, PREF_SAFE_MODE_COUNTER_KEY, 0);
+
+  ESP_LOGCONFIG(TAG, "Safe mode enabled. There have been %u suspected unsuccessful boot attempts.", counter);
+
+  if (counter >= num_attempts) {
+    global_preferences.put_uint8(PREF_TAG, PREF_SAFE_MODE_COUNTER_KEY, 0); // reset counter
+
+    ESP_LOGE(TAG, "Boot loop detected. Proceeding to safe mode.");
+    assert(App.get_wifi() != nullptr);
+
+    App.get_wifi()->setup_();
+    this->setup_();
+
+    ESP_LOGI(TAG, "Waiting for OTA attempt.");
+    uint32_t begin = millis();
+    while ((millis() - begin) < enable_time) {
+      this->loop_();
+      App.get_wifi()->loop_();
+    }
+    ESP_LOGE(TAG, "No OTA attempt made, restarting.");
+    ESP.restart();
+  } else {
+    // increment counter
+    auto new_value = static_cast<uint8_t>(counter + 1);
+    global_preferences.put_uint8(PREF_TAG, PREF_SAFE_MODE_COUNTER_KEY, new_value);
+  }
 }
 
 } // namespace esphomelib

--- a/src/esphomelib/ota_component.h
+++ b/src/esphomelib/ota_component.h
@@ -9,6 +9,12 @@
 
 #include "esphomelib/component.h"
 
+#ifdef ARDUINO_ARCH_ESP32
+  const uint16_t OTA_DEFAULT_PORT = 3232;
+#else
+  const uint16_t OTA_DEFAULT_PORT = 8266;
+#endif
+
 namespace esphomelib {
 
 /// OTAComponent provides a simple way to integrate Over-the-Air updates into your app using ArduinoOTA.
@@ -19,11 +25,7 @@ class OTAComponent : public Component {
    * @param port The port ArduinoOTA will listen on.
    * @param hostname The hostname ArduinoOTA will advertise.
    */
-#ifdef ARDUINO_ARCH_ESP32
-  explicit OTAComponent(uint16_t port = 3232, std::string hostname = "");
-#else
-  explicit OTAComponent(uint16_t port = 8266, std::string hostname = "");
-#endif
+  explicit OTAComponent(uint16_t port = OTA_DEFAULT_PORT, std::string hostname = "");
 
   /// Set ArduinoOTA to accept updates without authentication.
   void set_auth_open();
@@ -42,15 +44,36 @@ class OTAComponent : public Component {
    */
   void set_auth_password_hash(const std::string &hash);
 
-  uint16_t get_port() const;
+  /// Manually set the port OTA should listen on.
   void set_port(uint16_t port);
-  const std::string &get_hostname() const;
-  /// Empty for default hostname.
+
+  /// Set the hostname advertised with mDNS. Empty for default hostname.
   void set_hostname(const std::string &hostname);
+
+  /** Star OTA safe mode. When called at startup, this method will automatically detect boot loops.
+   *
+   * If a boot loop is detected (by `num_attempts` boots which each lasted less than `enable_time`),
+   * this method will block startup and enable just WiFi and OTA so that users can flash a new image.
+   *
+   * When in boot loop safe mode, if no OTA attempt is made within `enable_time` milliseconds, the device
+   * is restarted. If the device has stayed on for more than `enable_time` milliseconds, the boot is considered
+   * successful and the num_attempts counter is reset.
+   *
+   * @param num_attempts
+   * @param enable_time
+   */
+  void start_safe_mode(uint8_t num_attempts = 10, uint32_t enable_time = 60000);
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
 
   void setup() override;
   float get_setup_priority() const override;
   void loop() override;
+
+  const std::string &get_hostname() const;
+
+  uint16_t get_port() const;
 
  private:
   enum { OPEN, PLAINTEXT, HASH } auth_type_;
@@ -64,6 +87,9 @@ class OTAComponent : public Component {
   std::string hostname_;
   WiFiServer *server_;
   bool ota_triggered_{false}; ///< stores whether OTA is currently active.
+  bool has_safe_mode_{false}; ///< stores whether safe mode can be enabled.
+  uint32_t safe_mode_start_time_; ///<stores when safe mode was enabled.
+  uint32_t safe_mode_enable_time_{60000}; ///< The time safe mode should be on for.
 };
 
 } // namespace esphomelib

--- a/src/esphomelib/ota_component.h
+++ b/src/esphomelib/ota_component.h
@@ -59,10 +59,10 @@ class OTAComponent : public Component {
    * is restarted. If the device has stayed on for more than `enable_time` milliseconds, the boot is considered
    * successful and the num_attempts counter is reset.
    *
-   * @param num_attempts
-   * @param enable_time
+   * @param num_attempts The number of failed boot attempts until which time safe mode should be enabled.
+   * @param enable_time The time in ms safe mode should be on before restarting.
    */
-  void start_safe_mode(uint8_t num_attempts = 10, uint32_t enable_time = 60000);
+  void start_safe_mode(uint8_t num_attempts = 10, uint32_t enable_time = 120000);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)

--- a/src/esphomelib/sensor/mqtt_sensor_component.cpp
+++ b/src/esphomelib/sensor/mqtt_sensor_component.cpp
@@ -25,7 +25,7 @@ void MQTTSensorComponent::setup() {
 
   this->send_discovery([&](JsonBuffer &buffer, JsonObject &root) {
     if (!this->unit_of_measurement_.empty())
-      root["unit_of_measurement"] = buffer.strdup(this->unit_of_measurement_.c_str());
+      root["unit_of_measurement"] = this->unit_of_measurement_;
 
     if (this->expire_after_.defined) {
       root["expire_after"] = this->expire_after_.value / 1000;

--- a/src/esphomelib/wifi_component.cpp
+++ b/src/esphomelib/wifi_component.cpp
@@ -25,10 +25,10 @@ float WiFiComponent::get_setup_priority() const {
 }
 
 void WiFiComponent::setup() {
-  ESP_LOGD(TAG, "Setting up WiFi...");
+  ESP_LOGCONFIG(TAG, "Setting up WiFi...");
   WiFi.onEvent(on_wifi_event);
   delay(10);
-  ESP_LOGD(TAG, "    Connecting to '%s'", this->ssid_.c_str());
+  ESP_LOGCONFIG(TAG, "    SSID: '%s'", this->ssid_.c_str());
 
   WiFi.persistent(false);
   WiFi.mode(WIFI_STA);
@@ -36,7 +36,7 @@ void WiFiComponent::setup() {
   WiFi.setAutoReconnect(false);
 
   if (!this->hostname_.empty()) {
-    ESP_LOGV(TAG, "    Hostname: '%s'", this->hostname_.c_str());
+    ESP_LOGCONFIG(TAG, "    Hostname: '%s'", this->hostname_.c_str());
 #ifdef ARDUINO_ARCH_ESP32
     WiFi.setHostname(this->hostname_.c_str());
 #else
@@ -45,13 +45,13 @@ void WiFiComponent::setup() {
   }
 
   if (this->manual_ip_) {
-    ESP_LOGV(TAG, "    Static IP: '%s'", this->manual_ip_->static_ip.toString().c_str());
-    ESP_LOGV(TAG, "    Gateway: '%s'", this->manual_ip_->gateway.toString().c_str());
-    ESP_LOGV(TAG, "    Subnet: '%s'", this->manual_ip_->subnet.toString().c_str());
+    ESP_LOGCONFIG(TAG, "    Static IP: '%s'", this->manual_ip_->static_ip.toString().c_str());
+    ESP_LOGCONFIG(TAG, "    Gateway: '%s'", this->manual_ip_->gateway.toString().c_str());
+    ESP_LOGCONFIG(TAG, "    Subnet: '%s'", this->manual_ip_->subnet.toString().c_str());
     if (!is_empty(this->manual_ip_->dns1))
-      ESP_LOGV(TAG, "    DNS 1: '%s'", this->manual_ip_->dns1.toString().c_str());
+      ESP_LOGCONFIG(TAG, "    DNS 1: '%s'", this->manual_ip_->dns1.toString().c_str());
     if (!is_empty(this->manual_ip_->dns2))
-      ESP_LOGV(TAG, "    DNS 2: '%s'", this->manual_ip_->dns2.toString().c_str());
+      ESP_LOGCONFIG(TAG, "    DNS 2: '%s'", this->manual_ip_->dns2.toString().c_str());
     WiFi.config(this->manual_ip_->static_ip, this->manual_ip_->gateway, this->manual_ip_->subnet,
                 this->manual_ip_->dns1, this->manual_ip_->dns2);
   }
@@ -62,7 +62,7 @@ void WiFiComponent::setup() {
 
 void WiFiComponent::loop() {
   if (WiFi.status() != WL_CONNECTED) {
-    ESP_LOGD(TAG, "Reconnecting WiFi...");
+    ESP_LOGI(TAG, "Reconnecting WiFi...");
 #ifdef ARDUINO_ARCH_ESP32
     esp_wifi_connect();
 #else
@@ -107,7 +107,7 @@ void WiFiComponent::on_wifi_event(WiFiEvent_t event) {
     case WIFI_EVENT_STAMODE_DHCP_TIMEOUT: event_name = "STA DHCP timeout";
       break;
 #endif
-    default:event_name = "";
+    default:event_name = "UNKNOWN";
       break;
   }
 


### PR DESCRIPTION
This time for real ;) (messed up the 1.0.0 version logs, had it enabled locally but didn't push it)

## Introducing OTA Safe Mode

Have you ever had it happen that you accidentally uploaded a faulty OTA update to your ESP device and accidentally broke the runtime so you had to get out the old USB cable? Well, with OTA Safe mode by esphomelib no more!

If you include change your `init_log()` line to the following:

```cpp
App.init_ota()->start_safe_mode();
```

your ESP board will automatically detect boot loops and go into OTA update mode without running any of the Application mode for 2 minutes. So in those phases you can still upload your code via OTA and never have to use USB cables anymore 🎉🎉🎉

Also, the Application storage logic got revamped a bit, now esphomelib stores the `Application` instance as the global variable `App`; it was silly to have the user store the instance anyway
