### PR TITLE
MQTT Home Assistant Icon

### DIFF
--- a/src/esphomelib/binary_sensor/binary_sensor.cpp
+++ b/src/esphomelib/binary_sensor/binary_sensor.cpp
@@ -23,7 +23,6 @@ bool BinarySensor::is_inverted() const {
 void BinarySensor::set_inverted(bool inverted) {
   this->inverted_ = inverted;
 }
-BinarySensor::BinarySensor() : inverted_(false) {};
 
 } // namespace binary_sensor
 

--- a/src/esphomelib/binary_sensor/binary_sensor.h
+++ b/src/esphomelib/binary_sensor/binary_sensor.h
@@ -22,15 +22,13 @@ using binary_callback_t = std::function<void(bool)>;
  */
 class BinarySensor {
  public:
-  BinarySensor();
-
   /** Set callback for state changes.
    *
    * @param callback The void(bool) callback.
    */
   virtual void set_on_new_state_callback(binary_callback_t callback);
 
-  bool is_inverted() const;
+  /// Set the inverted state of this binary sensor. If true, each published value will be inverted.
   void set_inverted(bool inverted);
 
   /** Publish a new state.
@@ -41,9 +39,14 @@ class BinarySensor {
    */
   virtual void publish_state(bool state);
 
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  /// Return whether all states of this binary sensor should be inverted.
+  bool is_inverted() const;
+
  protected:
-  binary_callback_t new_state_callback_;
-  bool inverted_;
+  binary_callback_t new_state_callback_{nullptr};
+  bool inverted_{false};
 };
 
 } // namespace binary_sensor

--- a/src/esphomelib/input/pulse_counter.cpp
+++ b/src/esphomelib/input/pulse_counter.cpp
@@ -117,6 +117,9 @@ float PulseCounterSensorComponent::get_setup_priority() const {
 std::string PulseCounterSensorComponent::unit_of_measurement() {
   return "pulses/min";
 }
+std::string PulseCounterSensorComponent::icon() {
+  return "mdi:pulse";
+}
 gpio_pull_mode_t PulseCounterSensorComponent::get_pull_mode() const {
   return this->pull_mode_;
 }

--- a/src/esphomelib/input/pulse_counter.h
+++ b/src/esphomelib/input/pulse_counter.h
@@ -81,7 +81,11 @@ class PulseCounterSensorComponent : public Component, public sensor::Sensor {
   pcnt_count_mode_t get_rising_edge_mode() const;
   pcnt_count_mode_t get_falling_edge_mode() const;
 
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  /// Unit of measurement is "pulses/min".
   std::string unit_of_measurement() override;
+  std::string icon() override;
   void setup() override;
   float get_setup_priority() const override;
   uint8_t get_pin() const;

--- a/src/esphomelib/output/ir_transmitter_component.cpp
+++ b/src/esphomelib/output/ir_transmitter_component.cpp
@@ -281,6 +281,9 @@ void IRTransmitterComponent::DataTransmitter::turn_off() {
   // Turning off does nothing
   this->publish_state(false);
 }
+std::string IRTransmitterComponent::DataTransmitter::icon() {
+  return "mdi:remote";
+}
 
 rmt_channel_t next_rmt_channel = RMT_CHANNEL_0;
 

--- a/src/esphomelib/output/ir_transmitter_component.h
+++ b/src/esphomelib/output/ir_transmitter_component.h
@@ -104,6 +104,8 @@ class IRTransmitterComponent : public Component {
 
     void turn_on() override;
     void turn_off() override;
+
+    std::string icon() override;
    private:
     ir::SendData send_data_;
     IRTransmitterComponent *parent_;

--- a/src/esphomelib/sensor/mqtt_sensor_component.cpp
+++ b/src/esphomelib/sensor/mqtt_sensor_component.cpp
@@ -21,15 +21,21 @@ void MQTTSensorComponent::setup() {
   ESP_LOGCONFIG(TAG, "    Unit of Measurement: '%s'", this->unit_of_measurement_.c_str());
   if (this->override_accuracy_decimals_.defined)
     ESP_LOGCONFIG(TAG, "    Override Accuracy Decimals: %i", this->override_accuracy_decimals_.value);
+  if (!this->icon_.empty())
+    ESP_LOGCONFIG(TAG, "    Icon: '%s'", this->icon_.c_str());
+  ESP_LOGCONFIG(TAG, "    # Filters: %u", this->filters_.size());
 
 
   this->send_discovery([&](JsonBuffer &buffer, JsonObject &root) {
     if (!this->unit_of_measurement_.empty())
       root["unit_of_measurement"] = this->unit_of_measurement_;
 
-    if (this->expire_after_.defined) {
+    if (this->expire_after_.defined)
       root["expire_after"] = this->expire_after_.value / 1000;
-    }
+
+    // TODO: Enable this once a new Home Assistant version is out.
+    // if (!this->icon_.empty())
+    //   root["icon"] = this->icon_;
   }, true, false); // enable state topic, disable command topic
 }
 
@@ -148,6 +154,12 @@ void MQTTSensorComponent::set_filters(const std::vector<Filter *> &filters) {
 }
 void MQTTSensorComponent::add_filter_out_value_filter(float values_to_filter_out) {
   this->add_filter(new FilterOutValueFilter(values_to_filter_out));
+}
+void MQTTSensorComponent::set_icon(const std::string &icon) {
+  this->icon_ = icon;
+}
+const std::string &MQTTSensorComponent::get_icon() const {
+  return this->icon_;
 }
 
 } // namespace sensor

--- a/src/esphomelib/sensor/mqtt_sensor_component.h
+++ b/src/esphomelib/sensor/mqtt_sensor_component.h
@@ -29,10 +29,23 @@ class MQTTSensorComponent : public mqtt::MQTTComponent {
   /** Manually set the unit of measurement advertised to Home Assistant.
    *
    * This is automatically set by the constructor, but can later be overriden.
+   * * Set the value to "" to disable automatic unit of measurement reporting to Home Assistant.
    *
    * @param unit_of_measurement The unit of measurement,
    */
   void set_unit_of_measurement(const std::string &unit_of_measurement);
+
+  /** Manually set the icon advertised to Home Assistant.
+   *
+   * This is automatically set by the constructor, but can later be overriden.
+   * Set the value to "" to disable automatic icon reporting to Home Assistant.
+   *
+   * Note that this is disabled for now and the method is just here to create the API
+   * before a new Home Assistant release is out.
+   *
+   * @param icon The icon, for example "mdi:flash".
+   */
+  void set_icon(const std::string &icon);
 
   /** Override the accuracy in decimals that this value should use for reporting value.
    *
@@ -46,6 +59,7 @@ class MQTTSensorComponent : public mqtt::MQTTComponent {
 
   /// Setup an expiry
   void set_expire_after(uint32_t expire_after);
+  /// Disable Home Assistant value exiry.
   void disable_expire_after();
 
   /// Add a filter to the filter chain. Will be appended to the back.
@@ -136,8 +150,11 @@ class MQTTSensorComponent : public mqtt::MQTTComponent {
   /// Get the overriden accuracy in decimals, if set.
   const Optional<int8_t> &get_override_accuracy_decimals() const;
 
-  /// Get the unit of measurements used advertised to Home Assistant.
+  /// Get the unit of measurements advertised to Home Assistant.
   const std::string &get_unit_of_measurement() const;
+
+  /// Get the icon advertised to Home Assistant.
+  const std::string &get_icon() const;
 
   /** Return the vector of filters this component uses for its value calculations.
    *
@@ -158,6 +175,7 @@ class MQTTSensorComponent : public mqtt::MQTTComponent {
 
  private:
   std::string unit_of_measurement_;
+  std::string icon_;
   Optional<uint32_t> expire_after_;
   Optional<int8_t> override_accuracy_decimals_;
   std::vector<Filter *> filters_;

--- a/src/esphomelib/sensor/sensor.cpp
+++ b/src/esphomelib/sensor/sensor.cpp
@@ -30,6 +30,12 @@ void Sensor::set_update_interval(uint32_t update_interval) {
 Sensor::Sensor(uint32_t update_interval) : update_interval_(update_interval) {
 
 }
+std::string Sensor::unit_of_measurement() {
+  return "";
+}
+std::string Sensor::icon() {
+  return "";
+}
 
 std::string TemperatureSensor::unit_of_measurement() {
   return "°C";
@@ -37,25 +43,35 @@ std::string TemperatureSensor::unit_of_measurement() {
 TemperatureSensor::TemperatureSensor(uint32_t update_interval) : Sensor(update_interval) {
 
 }
+std::string TemperatureSensor::icon() {
+  // Home Assistant will automatically chose the correct icon for sensors with
+  // a temperature unit_of_measurement, so disable icon to save discovery payload
+  // size.
+  return "";
+}
+
+HumiditySensor::HumiditySensor(uint32_t update_interval) : Sensor(update_interval) { }
 
 std::string HumiditySensor::unit_of_measurement() {
   return "%";
 }
-HumiditySensor::HumiditySensor(uint32_t update_interval) : Sensor(update_interval) {
-
+std::string HumiditySensor::icon() {
+  return "mdi:water-percent";
 }
 
-VoltageSensor::VoltageSensor(uint32_t update_interval) : Sensor(update_interval) {
-
-}
+VoltageSensor::VoltageSensor(uint32_t update_interval) : Sensor(update_interval) { }
 std::string VoltageSensor::unit_of_measurement() {
   return "V";
 }
-DistanceSensor::DistanceSensor(uint32_t update_interval) : Sensor(update_interval) {
-
+std::string VoltageSensor::icon() {
+  return "mdi:flash";
 }
+DistanceSensor::DistanceSensor(uint32_t update_interval) : Sensor(update_interval) { }
 std::string DistanceSensor::unit_of_measurement() {
   return "m";
+}
+std::string DistanceSensor::icon() {
+  return "mdi:arrow-expand-vertical";
 }
 } // namespace sensor
 

--- a/src/esphomelib/sensor/sensor.h
+++ b/src/esphomelib/sensor/sensor.h
@@ -21,16 +21,52 @@ using sensor_callback_t = std::function<void(float, int8_t)>;
  */
 class Sensor {
  public:
+  /** Initialize this sensor with the given update interval in ms.
+   *
+   * If your Sensor isn't a polling sensor, you can pass 0 to the update interval.
+   *
+   * @param update_interval The update interval in ms.
+   */
   explicit Sensor(uint32_t update_interval);
 
-  virtual std::string unit_of_measurement() = 0;
+  /// Manually set the update interval in ms that the sensor should update its values.
+  virtual void set_update_interval(uint32_t update_interval);
 
-  void set_new_value_callback(sensor_callback_t callback);
-
+  // ========== OVERRIDE METHODS ==========
+  // (You'll only need this when creating your own custom sensor)
+  /** Push a new value to the MQTT front-end.
+   *
+   * Note that you should publish the raw value here, i.e. without any rounding as the user
+   * can later override this accuracy.
+   *
+   * @param value The floating point value.
+   * @param accuracy_decimals The accuracy in decimal points. The user can customize this.
+   */
   void push_new_value(float value, int8_t accuracy_decimals);
 
+  /** Override this to set the Home Assistant unit of measurement for this sensor.
+   *
+   * Return "" to disable this feature.
+   *
+   * @return The icon of this sensor, for example "°C".
+   */
+  virtual std::string unit_of_measurement();
+
+  /** Override this to set the Home Assistant icon for this sensor.
+   *
+   * Return "" to disable this feature.
+   *
+   * @return The icon of this sensor, for example "mdi:battery".
+   */
+  virtual std::string icon();
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  /// Get the update interval in ms of this sensor.
   virtual uint32_t get_update_interval() const;
-  virtual void set_update_interval(uint32_t update_interval);
+
+  /// The MQTT sensor class uses this to register itself as a listener for new values.
+  void set_new_value_callback(sensor_callback_t callback);
 
  protected:
   sensor_callback_t callback_{nullptr};
@@ -41,24 +77,28 @@ class TemperatureSensor : public Sensor {
  public:
   explicit TemperatureSensor(uint32_t update_interval);
   std::string unit_of_measurement() override;
+  std::string icon() override;
 };
 
 class HumiditySensor : public Sensor {
  public:
   explicit HumiditySensor(uint32_t update_interval);
   std::string unit_of_measurement() override;
+  std::string icon() override;
 };
 
 class VoltageSensor : public Sensor {
  public:
   explicit VoltageSensor(uint32_t update_interval);
   std::string unit_of_measurement() override;
+  std::string icon() override;
 };
 
 class DistanceSensor : public Sensor {
  public:
   explicit DistanceSensor(uint32_t update_interval);
   std::string unit_of_measurement() override;
+  std::string icon() override;
 };
 
 } // namespace sensor

--- a/src/esphomelib/switch_platform/mqtt_switch_component.h
+++ b/src/esphomelib/switch_platform/mqtt_switch_component.h
@@ -21,7 +21,11 @@ class MQTTSwitchComponent : public binary_sensor::MQTTBinarySensorComponent {
  public:
   explicit MQTTSwitchComponent(std::string friendly_name, switch_platform::Switch *switch_ = nullptr);
 
-  void set_on_set_state_callback(const binary_sensor::binary_callback_t &set_state_callback);
+  /// Set the internal switch object used for sending states, does not register the state callback.
+  void set_switch(Switch *switch_);
+
+  /// Set the icon for this switch. "" for no icon.
+  void set_icon(const std::string &icon);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -31,15 +35,22 @@ class MQTTSwitchComponent : public binary_sensor::MQTTBinarySensorComponent {
   binary_sensor::binary_callback_t create_on_new_state_callback() override;
 
  protected:
-  const binary_sensor::binary_callback_t &get_on_set_state_callback() const;
-  
+  /// Get the internal switch use for setting state.
+  Switch *get_switch() const;
+
+  /// "switch" component type.
   std::string component_type() const override;
 
+  /// Helper method to turn the switch on.
   void turn_on();
-
+  /// Helper method to turn the switch off.
   void turn_off();
 
-  binary_sensor::binary_callback_t on_set_state_callback_{nullptr};
+  /// Get the icon for this switch.
+  const std::string &get_icon() const;
+
+  std::string icon_;
+  Switch *switch_{nullptr};
 };
 
 } // namespace switch_platform

--- a/src/esphomelib/switch_platform/switch.cpp
+++ b/src/esphomelib/switch_platform/switch.cpp
@@ -8,13 +8,9 @@ namespace esphomelib {
 
 namespace switch_platform {
 
-binary_sensor::binary_callback_t Switch::create_on_set_state_callback() {
-  return [&](bool state) {
-    if (state) this->turn_on();
-    else this->turn_off();
-  };
+std::string Switch::icon() {
+  return "";
 }
-Switch::Switch() : BinarySensor() {}
 
 } // namespace switch_platform
 

--- a/src/esphomelib/switch_platform/switch.h
+++ b/src/esphomelib/switch_platform/switch.h
@@ -18,12 +18,16 @@ namespace switch_platform {
  */
 class Switch : public binary_sensor::BinarySensor {
  public:
-  Switch();
-
   virtual void turn_on() = 0;
   virtual void turn_off() = 0;
 
-  binary_sensor::binary_callback_t create_on_set_state_callback();
+  /** Override this to set the Home Assistant icon for this switch.
+   *
+   * Return "" to disable this feature.
+   *
+   * @return The icon of this switch, for example "mdi:fan".
+   */
+  virtual std::string icon();
 };
 
 } // namespace switch_platform


### PR DESCRIPTION
See https://github.com/home-assistant/home-assistant/pull/13304, enables sensors and switches to set an icon.

This PR only adds the API for this feature, but it isn't enabled by default to not break discovery (because Home Assistant checks the discovery JSON with the schema).