### PR TITLE
Polling Sensor Abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ framework = arduino
 lib_deps = esphomelib
 build_flags =
     -DMQTT_MAX_PACKET_SIZE=512
+    -DARDUINOJSON_ENABLE_STD_STRING
 ```
 
 ... or for [ESP8266-based boards](http://docs.platformio.org/en/latest/platforms/espressif8266.html#boards):
@@ -94,6 +95,7 @@ platform = espressif8266
 board = nodemcuv2
 build_flags =
     -DMQTT_MAX_PACKET_SIZE=512
+    -DARDUINOJSON_ENABLE_STD_STRING
 ```
 
 Finally, create a new source file in the `src/` folder (for example `main.cpp`) and start coding with esphomelib.

--- a/library.json
+++ b/library.json
@@ -38,9 +38,8 @@
     }
   ],
   "build": {
-    "flags": [
-      "-DMQTT_MAX_PACKET_SIZE=512",
-      "-DARDUINOJSON_ENABLE_STD_STRING"
+    "unflags": [
+      "-fno-rtti"
     ]
   },
   "license": "GPL-3.0",

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ lib_deps =
 build_flags =
     -DMQTT_MAX_PACKET_SIZE=512
     -DARDUINOJSON_ENABLE_STD_STRING
+build_unflags = -fno-rtti
 src_filter = +<src>
 
 [env:livingroom]
@@ -32,6 +33,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 src_filter = ${common.src_filter} +<examples/livingroom.cpp>
 
 [env:dht-dallas-sensors]
@@ -40,6 +42,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 src_filter = ${common.src_filter} +<examples/dht-dallas-sensors.cpp>
 
 [env:switch-binarysensor]
@@ -48,6 +51,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 src_filter = ${common.src_filter} +<examples/switch-binarysensor.cpp>
 
 [env:fan-example]
@@ -56,6 +60,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 src_filter = ${common.src_filter} +<examples/fan-example.cpp>
 
 [env:lights]
@@ -64,6 +69,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 src_filter = ${common.src_filter} +<examples/lights.cpp>
 
 [env:livingroom8266]
@@ -72,4 +78,5 @@ board = nodemcuv2
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
 src_filter = ${common.src_filter} +<examples/livingroom8266.cpp>

--- a/src/esphomelib/input/adc_component.h
+++ b/src/esphomelib/input/adc_component.h
@@ -17,12 +17,14 @@ namespace esphomelib {
 
 namespace input {
 
-class ADCSensorComponent : public Component, public sensor::VoltageSensor {
+class ADCSensorComponent : public PollingComponent, public sensor::VoltageSensor {
  public:
   explicit ADCSensorComponent(GPIOInputPin pin, uint32_t update_interval = 15000);
 
   GPIOInputPin &get_pin();
   void set_pin(const GPIOInputPin &pin);
+
+  void update() override;
 
   void setup() override;
   float get_setup_priority() const override;

--- a/src/esphomelib/input/dallas_component.cpp
+++ b/src/esphomelib/input/dallas_component.cpp
@@ -134,7 +134,7 @@ OneWire *DallasComponent::get_one_wire() const {
 DallasTemperatureSensor::DallasTemperatureSensor(uint64_t address,
                                                  uint8_t resolution,
                                                  uint32_t update_interval)
-    : TemperatureSensor(update_interval) {
+    : TemperatureSensor(), PollingObject(update_interval) {
   this->set_address(address);
   this->set_resolution(resolution);
 }

--- a/src/esphomelib/input/dallas_component.h
+++ b/src/esphomelib/input/dallas_component.h
@@ -13,7 +13,7 @@ namespace esphomelib {
 
 namespace input {
 
-class DallasTemperatureSensor : public sensor::TemperatureSensor {
+class DallasTemperatureSensor : public sensor::TemperatureSensor, public PollingObject {
  public:
   DallasTemperatureSensor(uint64_t address, uint8_t resolution, uint32_t update_interval);
 

--- a/src/esphomelib/input/dht_component.h
+++ b/src/esphomelib/input/dht_component.h
@@ -13,8 +13,18 @@ namespace esphomelib {
 
 namespace input {
 
+class DHTTemperatureSensor : public sensor::TemperatureSensor, public PollingObject {
+ public:
+  explicit DHTTemperatureSensor(uint32_t update_interval);
+};
+
+class DHTHumiditySensor : public sensor::HumiditySensor, public PollingObject {
+ public:
+  explicit DHTHumiditySensor(uint32_t update_interval);
+};
+
 /// DHTComponent - Component for reading temperature/humidity measurements from DHT11/DHT22 sensors.
-class DHTComponent : public Component {
+class DHTComponent : public Component, public PollingObject {
  public:
   /** Construct a DHTComponent.
    *
@@ -23,11 +33,14 @@ class DHTComponent : public Component {
    */
   explicit DHTComponent(uint8_t pin, uint32_t update_interval = 15000);
 
+  void set_pin(uint8_t pin);
+  void set_update_interval(uint32_t update_interval) override;
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  uint8_t get_pin() const;
   sensor::TemperatureSensor *get_temperature_sensor() const;
   sensor::HumiditySensor *get_humidity_sensor() const;
-
-  uint8_t get_pin() const;
-  void set_pin(uint8_t pin);
 
   /** Manually select the DHT model.
    *
@@ -46,8 +59,8 @@ class DHTComponent : public Component {
   uint8_t pin_;
   DHT dht_;
   DHT::DHT_MODEL_t model_{DHT::AUTO_DETECT};
-  sensor::TemperatureSensor *temperature_sensor_;
-  sensor::HumiditySensor *humidity_sensor_;
+  DHTTemperatureSensor *temperature_sensor_;
+  DHTHumiditySensor *humidity_sensor_;
 };
 
 } // namespace input

--- a/src/esphomelib/input/pulse_counter.h
+++ b/src/esphomelib/input/pulse_counter.h
@@ -31,7 +31,7 @@ namespace input {
  * The pulse counter defaults to reporting a value of the measurement unit "pulses/min". To
  * modify this behavior, use filters in MQTTSensor.
  */
-class PulseCounterSensorComponent : public Component, public sensor::Sensor {
+class PulseCounterSensorComponent : public PollingComponent, public sensor::Sensor {
  public:
   /** Construct the Pulse Counter instance with the provided pin and update interval.
    *
@@ -87,6 +87,7 @@ class PulseCounterSensorComponent : public Component, public sensor::Sensor {
   std::string unit_of_measurement() override;
   std::string icon() override;
   void setup() override;
+  void update() override;
   float get_setup_priority() const override;
   uint8_t get_pin() const;
 

--- a/src/esphomelib/input/ultrasonic_sensor.h
+++ b/src/esphomelib/input/ultrasonic_sensor.h
@@ -46,7 +46,7 @@ const float SPEED_OF_SOUND_M_PER_US = 0.000343f;
  * Note: The MQTTSenorComponent will create a moving average over these values by default, to disable this behavior,
  *       call ultrasonic->mqtt->clear_filters() or similar like above.
  */
-class UltrasonicSensorComponent : public Component, public sensor::DistanceSensor {
+class UltrasonicSensorComponent : public PollingComponent, public sensor::DistanceSensor {
  public:
   /** Construct the ultrasonic sensor with the specified trigger pin and echo pin.
    *
@@ -78,6 +78,8 @@ class UltrasonicSensorComponent : public Component, public sensor::DistanceSenso
 
   /// Set up pins and register interval.
   void setup() override;
+
+  void update() override;
 
   /// Hardware setup priority, before MQTT and WiFi.
   float get_setup_priority() const override;

--- a/src/esphomelib/sensor/mqtt_sensor_component.cpp
+++ b/src/esphomelib/sensor/mqtt_sensor_component.cpp
@@ -138,8 +138,15 @@ MQTTSensorComponent::MQTTSensorComponent(std::string friendly_name, Sensor *sens
   // By default, smooth over the last 15 values using sliding window moving average.
   this->add_sliding_window_average_filter(15, 15);
   // By default, expire after 30 missed values, or two full missed sliding windows.
-  uint32_t expire_after = sensor->get_update_interval() * 30;
-  this->set_expire_after(expire_after);
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "OCDFAInspection"
+  auto *polling = dynamic_cast<PollingObject *>(sensor);
+#pragma clang diagnostic pop
+  if (polling != nullptr) {
+    // If this is a polling sensor
+    uint32_t expire_after = polling->get_update_interval() * 30;
+    this->set_expire_after(expire_after);
+  }
   this->set_unit_of_measurement(sensor->unit_of_measurement());
 }
 void MQTTSensorComponent::add_multiply_filter(float multiplier) {

--- a/src/esphomelib/sensor/sensor.cpp
+++ b/src/esphomelib/sensor/sensor.cpp
@@ -4,7 +4,7 @@
 
 #include "esphomelib/sensor/sensor.h"
 
-#include <utility>
+#include "esphomelib/log.h"
 
 namespace esphomelib {
 
@@ -20,16 +20,6 @@ void Sensor::push_new_value(float value, int8_t accuracy_decimals) {
   if (this->callback_)
     this->callback_(value, accuracy_decimals);
 }
-uint32_t Sensor::get_update_interval() const {
-  return this->update_interval_;
-}
-void Sensor::set_update_interval(uint32_t update_interval) {
-  this->update_interval_ = update_interval;
-}
-
-Sensor::Sensor(uint32_t update_interval) : update_interval_(update_interval) {
-
-}
 std::string Sensor::unit_of_measurement() {
   return "";
 }
@@ -40,17 +30,12 @@ std::string Sensor::icon() {
 std::string TemperatureSensor::unit_of_measurement() {
   return "°C";
 }
-TemperatureSensor::TemperatureSensor(uint32_t update_interval) : Sensor(update_interval) {
-
-}
 std::string TemperatureSensor::icon() {
   // Home Assistant will automatically chose the correct icon for sensors with
   // a temperature unit_of_measurement, so disable icon to save discovery payload
   // size.
   return "";
 }
-
-HumiditySensor::HumiditySensor(uint32_t update_interval) : Sensor(update_interval) { }
 
 std::string HumiditySensor::unit_of_measurement() {
   return "%";
@@ -59,20 +44,19 @@ std::string HumiditySensor::icon() {
   return "mdi:water-percent";
 }
 
-VoltageSensor::VoltageSensor(uint32_t update_interval) : Sensor(update_interval) { }
 std::string VoltageSensor::unit_of_measurement() {
   return "V";
 }
 std::string VoltageSensor::icon() {
   return "mdi:flash";
 }
-DistanceSensor::DistanceSensor(uint32_t update_interval) : Sensor(update_interval) { }
 std::string DistanceSensor::unit_of_measurement() {
   return "m";
 }
 std::string DistanceSensor::icon() {
   return "mdi:arrow-expand-vertical";
 }
+
 } // namespace sensor
 
 } // namespace esphomelib

--- a/src/esphomelib/sensor/sensor.h
+++ b/src/esphomelib/sensor/sensor.h
@@ -8,6 +8,7 @@
 #include <functional>
 
 #include "esphomelib/component.h"
+#include "esphomelib/helpers.h"
 
 namespace esphomelib {
 
@@ -21,17 +22,6 @@ using sensor_callback_t = std::function<void(float, int8_t)>;
  */
 class Sensor {
  public:
-  /** Initialize this sensor with the given update interval in ms.
-   *
-   * If your Sensor isn't a polling sensor, you can pass 0 to the update interval.
-   *
-   * @param update_interval The update interval in ms.
-   */
-  explicit Sensor(uint32_t update_interval);
-
-  /// Manually set the update interval in ms that the sensor should update its values.
-  virtual void set_update_interval(uint32_t update_interval);
-
   // ========== OVERRIDE METHODS ==========
   // (You'll only need this when creating your own custom sensor)
   /** Push a new value to the MQTT front-end.
@@ -62,41 +52,33 @@ class Sensor {
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
-  /// Get the update interval in ms of this sensor.
-  virtual uint32_t get_update_interval() const;
-
   /// The MQTT sensor class uses this to register itself as a listener for new values.
   void set_new_value_callback(sensor_callback_t callback);
 
  protected:
   sensor_callback_t callback_{nullptr};
-  uint32_t update_interval_{0};
 };
 
 class TemperatureSensor : public Sensor {
  public:
-  explicit TemperatureSensor(uint32_t update_interval);
   std::string unit_of_measurement() override;
   std::string icon() override;
 };
 
 class HumiditySensor : public Sensor {
  public:
-  explicit HumiditySensor(uint32_t update_interval);
   std::string unit_of_measurement() override;
   std::string icon() override;
 };
 
 class VoltageSensor : public Sensor {
  public:
-  explicit VoltageSensor(uint32_t update_interval);
   std::string unit_of_measurement() override;
   std::string icon() override;
 };
 
 class DistanceSensor : public Sensor {
  public:
-  explicit DistanceSensor(uint32_t update_interval);
   std::string unit_of_measurement() override;
   std::string icon() override;
 };


### PR DESCRIPTION
Abstract away polling mode for sensors. 

There's 2 new classes now: `PollingObject` and `PollingComponent`. The former just has an `update_interval` attribute and getters/setters. The latter actually provides polling functionality: All subclass just have to implement `update()`, which will automatically be called for them with an interval of `update_interval`.

The MQTTSensor class now also checks this to automatically set an `expire_after` for Home Assistant discovery using `dynamic_cast<>` 😎

Todo:
- [x] Check the `-fno-rtti` build unflag actually works on all systems.