### PR TITLE
Sensor Accuracy API Improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ script:
   - platformio run -e fan-example
   - platformio run -e lights
   - platformio run -e livingroom8266
+  - platformio run -e custombmp180
 
 
 #

--- a/examples/custom-bmp180-sensor.cpp
+++ b/examples/custom-bmp180-sensor.cpp
@@ -28,10 +28,11 @@ class BMP180Sensor : public sensor::PollingSensorComponent {
 
   void update() override {
     int pressure = bmp.readPressure(); // in Pa, or 1/100 hPa
-    push_new_value(pressure / 100.0, 2); // convert to hPa, 2 decimal places of accuracy
+    push_new_value(pressure / 100.0); // convert to hPa
   }
 
   std::string unit_of_measurement() override { return "hPa"; }
+  int8_t accuracy_decimals() override { return 2; } // 2 decimal places of accuracy.
 };
 
 void setup() {

--- a/platformio.ini
+++ b/platformio.ini
@@ -80,3 +80,14 @@ lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
 build_unflags = ${common.build_unflags}
 src_filter = ${common.src_filter} +<examples/livingroom8266.cpp>
+
+[env:custombmp180]
+platform = espressif8266
+board = nodemcuv2
+framework = arduino
+lib_deps =
+    ${common.lib_deps}
+    Adafruit BMP085 Library
+build_flags = ${common.build_flags}
+build_unflags = ${common.build_unflags}
+src_filter = ${common.src_filter} +<examples/custom-bmp180-sensor.cpp>

--- a/src/esphomelib/application.cpp
+++ b/src/esphomelib/application.cpp
@@ -46,7 +46,8 @@ void Application::setup() {
 void Application::loop() {
   assert(this->application_state_ >= Component::SETUP && "Did you forget to call setup()?");
 
-  if (this->application_state_ == Component::SETUP) {
+  bool first_loop = this->application_state_ == Component::SETUP;
+  if (first_loop) {
     ESP_LOGI(TAG, "Running through first loop()");
     this->application_state_ = Component::LOOP;
   }
@@ -54,6 +55,9 @@ void Application::loop() {
   for (Component *component : this->components_)
     component->loop_();
   yield();
+
+  if (first_loop)
+    ESP_LOGI(TAG, "First loop finished successfully!");
 }
 
 WiFiComponent *Application::init_wifi(const std::string &ssid, const std::string &password) {

--- a/src/esphomelib/helpers.h
+++ b/src/esphomelib/helpers.h
@@ -96,7 +96,7 @@ struct Optional {
 
   operator bool() const; // NOLINT
 
-  bool defined;
+  bool defined{false};
   T value;
 };
 

--- a/src/esphomelib/input/adc_component.cpp
+++ b/src/esphomelib/input/adc_component.cpp
@@ -65,13 +65,16 @@ void ADCSensorComponent::update() {
       break;
   }
 #endif
-  this->push_new_value(value_v, 2);
+  this->push_new_value(value_v);
 }
 std::string ADCSensorComponent::unit_of_measurement() {
   return sensor::UNIT_OF_MEASUREMENT_VOLT;
 }
 std::string ADCSensorComponent::icon() {
   return sensor::ICON_VOLTAGE;
+}
+int8_t ADCSensorComponent::accuracy_decimals() {
+  return 2;
 }
 
 } // namespace input

--- a/src/esphomelib/input/adc_component.h
+++ b/src/esphomelib/input/adc_component.h
@@ -35,6 +35,7 @@ class ADCSensorComponent : public sensor::PollingSensorComponent {
 #endif
   std::string unit_of_measurement() override;
   std::string icon() override;
+  int8_t accuracy_decimals() override;
 
  protected:
   GPIOInputPin pin_;

--- a/src/esphomelib/input/dallas_component.cpp
+++ b/src/esphomelib/input/dallas_component.cpp
@@ -121,7 +121,7 @@ void DallasComponent::request_temperature(DallasTemperatureSensor *sensor) {
 
     if (temperature != DEVICE_DISCONNECTED_C) {
       ESP_LOGD(TAG, "%s: Got Temperature=%.1f°C", sensor->get_name().c_str(), temperature);
-      sensor->push_new_value(temperature, 1);
+      sensor->push_new_value(temperature);
     } else {
       ESP_LOGW(TAG, "%s: Invalid Temperature: %f", sensor->get_name().c_str(), temperature);
     }
@@ -180,6 +180,9 @@ uint32_t DallasTemperatureSensor::get_update_interval() const {
 }
 void DallasTemperatureSensor::set_update_interval(uint32_t update_interval) {
   this->update_interval_ = update_interval;
+}
+int8_t DallasTemperatureSensor::accuracy_decimals() {
+  return 1;
 }
 
 } // namespace input

--- a/src/esphomelib/input/dallas_component.h
+++ b/src/esphomelib/input/dallas_component.h
@@ -33,6 +33,7 @@ class DallasTemperatureSensor : public sensor::Sensor {
   std::string unit_of_measurement() override;
   std::string icon() override;
   uint32_t update_interval() override;
+  int8_t accuracy_decimals() override;
 
  protected:
   uint64_t address_;

--- a/src/esphomelib/input/dht_component.cpp
+++ b/src/esphomelib/input/dht_component.cpp
@@ -52,12 +52,12 @@ void DHTComponent::update() {
   ESP_LOGD(TAG, "Got Temperature=%.1f°C Humidity=%.1f%%", temperature, humidity);
 
   if (!isnan(temperature))
-    this->temperature_sensor_->push_new_value(temperature, this->dht_.getNumberOfDecimalsTemperature());
+    this->temperature_sensor_->push_new_value(temperature);
   else
     ESP_LOGW(TAG, "Invalid Temperature: %f!C", temperature);
 
   if (!isnan(humidity))
-    this->humidity_sensor_->push_new_value(humidity, this->dht_.getNumberOfDecimalsHumidity());
+    this->humidity_sensor_->push_new_value(humidity);
   else
     ESP_LOGW(TAG, "Invalid Humidity: %f%%", humidity);
 }
@@ -77,7 +77,7 @@ void DHTComponent::set_dht_model(DHT::DHT_MODEL_t model) {
   assert_construction_state(this);
   this->model_ = model;
 }
-const DHT &DHTComponent::get_dht() const {
+DHT &DHTComponent::get_dht() {
   return this->dht_;
 }
 DHTTemperatureSensor *DHTComponent::get_temperature_sensor() const {
@@ -98,6 +98,9 @@ uint32_t DHTTemperatureSensor::update_interval() {
   return this->parent_->get_update_interval();
 }
 DHTTemperatureSensor::DHTTemperatureSensor(DHTComponent *parent) : parent_(parent) {}
+int8_t DHTTemperatureSensor::accuracy_decimals() {
+  return this->parent_->get_dht().getNumberOfDecimalsTemperature();
+}
 
 std::string DHTHumiditySensor::unit_of_measurement() {
   return UNIT_OF_MEASUREMENT_PERCENT;
@@ -111,6 +114,9 @@ uint32_t DHTHumiditySensor::update_interval() {
   return this->parent_->get_update_interval();
 }
 DHTHumiditySensor::DHTHumiditySensor(DHTComponent *parent) : parent_(parent) {}
+int8_t DHTHumiditySensor::accuracy_decimals() {
+  return this->parent_->get_dht().getNumberOfDecimalsHumidity();
+}
 
 } // namespace input
 

--- a/src/esphomelib/input/dht_component.h
+++ b/src/esphomelib/input/dht_component.h
@@ -22,6 +22,7 @@ class DHTTemperatureSensor : public sensor::Sensor {
   std::string unit_of_measurement() override;
   std::string icon() override;
   uint32_t update_interval() override;
+  int8_t accuracy_decimals() override;
  protected:
   DHTComponent *parent_{nullptr};
 };
@@ -33,6 +34,7 @@ class DHTHumiditySensor : public sensor::Sensor {
   std::string unit_of_measurement() override;
   std::string icon() override;
   uint32_t update_interval() override;
+  int8_t accuracy_decimals() override;
  protected:
   DHTComponent *parent_{nullptr};
 };
@@ -63,7 +65,7 @@ class DHTComponent : public PollingComponent {
    */
   void set_dht_model(DHT::DHT_MODEL_t model);
 
-  const DHT &get_dht() const;
+  DHT &get_dht();
 
   void setup() override;
   void update() override;

--- a/src/esphomelib/input/pulse_counter.cpp
+++ b/src/esphomelib/input/pulse_counter.cpp
@@ -123,7 +123,10 @@ void PulseCounterSensorComponent::update() {
   float value = (60000.0f * delta) / float(this->get_update_interval()); // per minute
 
   ESP_LOGD(TAG, "%u: Retrieved counter (raw=%d): %0.2f pulses/min", this->pcnt_unit_, counter, value);
-  this->push_new_value(value, 2);
+  this->push_new_value(value);
+}
+int8_t PulseCounterSensorComponent::accuracy_decimals() {
+  return 2;
 }
 
 pcnt_unit_t next_pcnt_unit = PCNT_UNIT_0;

--- a/src/esphomelib/input/pulse_counter.h
+++ b/src/esphomelib/input/pulse_counter.h
@@ -86,6 +86,7 @@ class PulseCounterSensorComponent : public sensor::PollingSensorComponent {
   /// Unit of measurement is "pulses/min".
   std::string unit_of_measurement() override;
   std::string icon() override;
+  int8_t accuracy_decimals() override;
   void setup() override;
   void update() override;
   float get_setup_priority() const override;

--- a/src/esphomelib/input/ultrasonic_sensor.cpp
+++ b/src/esphomelib/input/ultrasonic_sensor.cpp
@@ -62,7 +62,7 @@ void UltrasonicSensorComponent::update() {
 
   ESP_LOGV(TAG, "Echo took %uµs (%fm)", time, result);
 
-  this->push_new_value(result, 2); // cm precision
+  this->push_new_value(result);
 }
 uint32_t UltrasonicSensorComponent::get_timeout_us() const {
   return this->timeout_us_;
@@ -92,6 +92,15 @@ uint32_t UltrasonicSensorComponent::get_pulse_time_us() const {
 }
 void UltrasonicSensorComponent::set_pulse_time_us(uint32_t pulse_time_us) {
   this->pulse_time_us_ = pulse_time_us;
+}
+std::string UltrasonicSensorComponent::unit_of_measurement() {
+  return sensor::UNIT_OF_MEASUREMENT_METER;
+}
+std::string UltrasonicSensorComponent::icon() {
+  return sensor::ICON_DISTANCE;
+}
+int8_t UltrasonicSensorComponent::accuracy_decimals() {
+  return 2; // cm precision
 }
 
 } // namespace input

--- a/src/esphomelib/input/ultrasonic_sensor.h
+++ b/src/esphomelib/input/ultrasonic_sensor.h
@@ -81,6 +81,10 @@ class UltrasonicSensorComponent : public sensor::PollingSensorComponent {
 
   void update() override;
 
+  std::string unit_of_measurement() override;
+  std::string icon() override;
+  int8_t accuracy_decimals() override;
+
   /// Hardware setup priority, before MQTT and WiFi.
   float get_setup_priority() const override;
 

--- a/src/esphomelib/sensor/mqtt_sensor_component.cpp
+++ b/src/esphomelib/sensor/mqtt_sensor_component.cpp
@@ -14,24 +14,33 @@ namespace sensor {
 
 static const char *TAG = "sensor::mqtt";
 
+MQTTSensorComponent::MQTTSensorComponent(std::string friendly_name, Sensor *sensor)
+    : MQTTComponent(std::move(friendly_name)) {
+  assert(sensor != nullptr);
+  this->sensor_ = sensor;
+  this->sensor_->add_new_value_callback(this->create_new_data_callback());
+
+  if (this->sensor_->update_interval() > 0) {
+    // By default, smooth over the last 15 values using sliding window moving average.
+    this->add_sliding_window_average_filter(15, 15);
+  }
+}
+
 void MQTTSensorComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MQTT Sensor '%s'", this->friendly_name_.c_str());
-  if (this->expire_after_.defined)
-    ESP_LOGCONFIG(TAG, "    Expire After: %u s", this->expire_after_.value / 1000);
-  ESP_LOGCONFIG(TAG, "    Unit of Measurement: '%s'", this->unit_of_measurement_.c_str());
-  if (this->override_accuracy_decimals_.defined)
-    ESP_LOGCONFIG(TAG, "    Override Accuracy Decimals: %i", this->override_accuracy_decimals_.value);
-  if (!this->icon_.empty())
-    ESP_LOGCONFIG(TAG, "    Icon: '%s'", this->icon_.c_str());
+  if (this->get_expire_after() > 0)
+    ESP_LOGCONFIG(TAG, "    Expire After: %us", this->get_expire_after() / 1000);
+  ESP_LOGCONFIG(TAG, "    Unit of Measurement: '%s'", this->get_unit_of_measurement().c_str());
+  ESP_LOGCONFIG(TAG, "    Accuracy Decimals: %i", this->get_accuracy_decimals());
+  ESP_LOGCONFIG(TAG, "    Icon: '%s'", this->get_icon().c_str());
   ESP_LOGCONFIG(TAG, "    # Filters: %u", this->filters_.size());
 
-
   this->send_discovery([&](JsonBuffer &buffer, JsonObject &root) {
-    if (!this->unit_of_measurement_.empty())
-      root["unit_of_measurement"] = this->unit_of_measurement_;
+    if (!this->get_unit_of_measurement().empty())
+      root["unit_of_measurement"] = this->get_unit_of_measurement();
 
-    if (this->expire_after_.defined)
-      root["expire_after"] = this->expire_after_.value / 1000;
+    if (this->get_expire_after() > 0)
+      root["expire_after"] = this->get_expire_after() / 1000;
 
     // TODO: Enable this once a new Home Assistant version is out.
     // if (!this->icon_.empty())
@@ -40,12 +49,11 @@ void MQTTSensorComponent::setup() {
 }
 
 sensor_callback_t MQTTSensorComponent::create_new_data_callback() {
-  return [this](float value, int8_t accuracy_decimals) {
+  return [this](float value) {
     // This stores the current value after each filter step.
     float current_value = value;
 
-    ESP_LOGV(TAG, "'%s': Received new value %f with accuracy %d",
-             this->friendly_name_.c_str(), value, accuracy_decimals);
+    ESP_LOGV(TAG, "'%s': Received new value %f", this->friendly_name_.c_str(), value);
 
     for (unsigned int i = 0; i < this->filters_.size(); i++) {
       // Apply the filter
@@ -62,12 +70,8 @@ sensor_callback_t MQTTSensorComponent::create_new_data_callback() {
       current_value = optional_value.value;
     }
 
-    if (this->override_accuracy_decimals_.defined)
-      // Override accuracy_decimals if we were told to
-      accuracy_decimals = this->override_accuracy_decimals_;
-
     // All filters succeeded, push out the result.
-    this->push_out_value(current_value, accuracy_decimals);
+    this->push_out_value(current_value, this->get_accuracy_decimals());
   };
 }
 
@@ -75,6 +79,46 @@ std::string MQTTSensorComponent::component_type() const {
   return "sensor";
 }
 
+void MQTTSensorComponent::push_out_value(float value, int8_t accuracy_decimals) {
+  ESP_LOGD(TAG, "'%s': Pushing out value %f with accuracy %d",
+           this->friendly_name_.c_str(), value, accuracy_decimals);
+  auto multiplier = float(pow10(accuracy_decimals));
+  float value_rounded = roundf(value * multiplier) / multiplier;
+  char tmp[32]; // should be enough, but we should maybe improve this at some point.
+  dtostrf(value_rounded, 0, uint8_t(std::max(0, int(accuracy_decimals))), tmp);
+  this->send_message(this->get_state_topic(), tmp);
+}
+uint32_t MQTTSensorComponent::get_expire_after() const {
+  if (this->expire_after_.defined) {
+    return this->expire_after_.value;
+  } else {
+    // By default, expire after 30 missed values.
+    return this->sensor_->update_interval() * 30;
+  }
+}
+std::string MQTTSensorComponent::get_unit_of_measurement() const {
+  if (this->unit_of_measurement_.defined) {
+    return this->unit_of_measurement_.value;
+  } else {
+    assert(this->sensor_ != nullptr);
+    return this->sensor_->unit_of_measurement();
+  }
+}
+int8_t MQTTSensorComponent::get_accuracy_decimals() const {
+  if (this->accuracy_decimals_.defined) {
+    return this->accuracy_decimals_.value;
+  } else {
+    assert(this->sensor_ != nullptr);
+    return this->sensor_->accuracy_decimals();
+  }
+}
+std::string MQTTSensorComponent::get_icon() const {
+  if (this->icon_.defined) {
+    return this->icon_.value;
+  } else {
+    return this->sensor_->icon();
+  }
+}
 void MQTTSensorComponent::set_unit_of_measurement(const std::string &unit_of_measurement) {
   this->unit_of_measurement_ = unit_of_measurement;
 }
@@ -82,24 +126,14 @@ void MQTTSensorComponent::set_unit_of_measurement(const std::string &unit_of_mea
 void MQTTSensorComponent::set_expire_after(uint32_t expire_after) {
   this->expire_after_ = expire_after;
 }
-
-void MQTTSensorComponent::push_out_value(float value, int8_t accuracy_decimals) {
-  ESP_LOGD(TAG, "'%s': Pushing out value %f with accuracy %d",
-           this->friendly_name_.c_str(), value, accuracy_decimals);
-  auto multiplier = float(pow10(accuracy_decimals));
-  float value_rounded = roundf(value * multiplier) / multiplier;
-  char tmp[32];
-  dtostrf(value_rounded, 0, uint8_t(std::max(0, int(accuracy_decimals))), tmp);
-  this->send_message(this->get_state_topic(), tmp);
-}
-const std::string &MQTTSensorComponent::get_unit_of_measurement() const {
-  return this->unit_of_measurement_;
-}
-const Optional<uint32_t> &MQTTSensorComponent::get_expire_after() const {
-  return this->expire_after_;
-}
 void MQTTSensorComponent::disable_expire_after() {
-  this->expire_after_ = Optional<uint32_t>();
+  this->expire_after_ = 0;
+}
+void MQTTSensorComponent::set_icon(const std::string &icon) {
+  this->icon_ = icon;
+}
+void MQTTSensorComponent::set_accuracy_decimals(int8_t accuracy_decimals) {
+  this->accuracy_decimals_ = accuracy_decimals;
 }
 std::vector<Filter *> MQTTSensorComponent::get_filters() const {
   return this->filters_;
@@ -109,12 +143,6 @@ void MQTTSensorComponent::add_filter(Filter *filter) {
 }
 void MQTTSensorComponent::clear_filters() {
   this->filters_.clear();
-}
-const Optional<int8_t> &MQTTSensorComponent::get_override_accuracy_decimals() const {
-  return override_accuracy_decimals_;
-}
-void MQTTSensorComponent::override_accuracy_decimals(int8_t override_accuracy_decimals) {
-  this->override_accuracy_decimals_ = override_accuracy_decimals;
 }
 void MQTTSensorComponent::add_lambda_filter(lambda_filter_t filter) {
   this->add_filter(new LambdaFilter(std::move(filter)));
@@ -128,23 +156,6 @@ void MQTTSensorComponent::add_sliding_window_average_filter(size_t window_size, 
 void MQTTSensorComponent::add_exponential_moving_average_filter(float alpha, size_t send_every) {
   this->add_filter(new ExponentialMovingAverageFilter(alpha, send_every));
 }
-MQTTSensorComponent::MQTTSensorComponent(std::string friendly_name, Sensor *sensor)
-    : MQTTComponent(std::move(friendly_name)) {
-  if (sensor == nullptr)
-    // Disable automatic initialization
-    return;
-
-  sensor->add_new_value_callback(this->create_new_data_callback());
-  // By default, smooth over the last 15 values using sliding window moving average.
-  this->add_sliding_window_average_filter(15, 15);
-  // By default, expire after 30 missed values, or two full missed sliding windows.
-  if (sensor->update_interval() > 0) {
-    // If this is a polling sensor
-    uint32_t expire_after = sensor->update_interval() * 30;
-    this->set_expire_after(expire_after);
-  }
-  this->set_unit_of_measurement(sensor->unit_of_measurement());
-}
 void MQTTSensorComponent::add_multiply_filter(float multiplier) {
   this->add_filter(new MultiplyFilter(multiplier));
 }
@@ -157,12 +168,6 @@ void MQTTSensorComponent::set_filters(const std::vector<Filter *> &filters) {
 }
 void MQTTSensorComponent::add_filter_out_value_filter(float values_to_filter_out) {
   this->add_filter(new FilterOutValueFilter(values_to_filter_out));
-}
-void MQTTSensorComponent::set_icon(const std::string &icon) {
-  this->icon_ = icon;
-}
-const std::string &MQTTSensorComponent::get_icon() const {
-  return this->icon_;
 }
 
 } // namespace sensor

--- a/src/esphomelib/sensor/mqtt_sensor_component.h
+++ b/src/esphomelib/sensor/mqtt_sensor_component.h
@@ -53,11 +53,11 @@ class MQTTSensorComponent : public mqtt::MQTTComponent {
    * by the sensor. This method can be used to override the value. For example 0 means
    * 1.42 will be rounded to 1 and 2 means it will stay 1.42; also supports negative values.
    *
-   * @param override_accuracy_decimals The accuracy decimal that shall be used.
+   * @param accuracy_decimals The accuracy decimal that shall be used.
    */
-  void override_accuracy_decimals(int8_t override_accuracy_decimals);
+  void set_accuracy_decimals(int8_t accuracy_decimals);
 
-  /// Setup an expiry
+  /// Setup an expiry, 0 disables it
   void set_expire_after(uint32_t expire_after);
   /// Disable Home Assistant value exiry.
   void disable_expire_after();
@@ -144,17 +144,17 @@ class MQTTSensorComponent : public mqtt::MQTTComponent {
    */
   sensor_callback_t create_new_data_callback();
 
-  /// Get the expire_after in milliseconds used for Home Assistant discovery.
-  const Optional<uint32_t> &get_expire_after() const;
+  /// Get the expire_after in milliseconds used for Home Assistant discovery, first checks override.
+  uint32_t get_expire_after() const;
 
-  /// Get the overriden accuracy in decimals, if set.
-  const Optional<int8_t> &get_override_accuracy_decimals() const;
+  /// Get the accuracy in decimals used by this MQTT Sensor, first checks override, then sensor.
+  int8_t get_accuracy_decimals() const;
 
-  /// Get the unit of measurements advertised to Home Assistant.
-  const std::string &get_unit_of_measurement() const;
+  /// Get the unit of measurements advertised to Home Assistant. First checks override, then sensor.
+  std::string get_unit_of_measurement() const;
 
   /// Get the icon advertised to Home Assistant.
-  const std::string &get_icon() const;
+  std::string get_icon() const;
 
   /** Return the vector of filters this component uses for its value calculations.
    *
@@ -174,10 +174,11 @@ class MQTTSensorComponent : public mqtt::MQTTComponent {
   void push_out_value(float value, int8_t accuracy_decimals);
 
  protected:
-  std::string unit_of_measurement_;
-  std::string icon_;
-  Optional<uint32_t> expire_after_;
-  Optional<int8_t> override_accuracy_decimals_;
+  Sensor *sensor_{nullptr};
+  Optional<uint32_t> expire_after_; // Override the expire after advertised to Home Assistant
+  Optional<std::string> unit_of_measurement_; // Override the unit of measurement
+  Optional<std::string> icon_; // Override the icon advertised to Home Assistant, otherwise sensor's icon will be used.
+  Optional<int8_t> accuracy_decimals_; // Override the accuracy in decimals, otherwise the sensor's values will be used.
   std::vector<Filter *> filters_;
 };
 

--- a/src/esphomelib/sensor/sensor.cpp
+++ b/src/esphomelib/sensor/sensor.cpp
@@ -16,8 +16,8 @@ void Sensor::add_new_value_callback(sensor_callback_t callback) {
   this->callback_.add(std::move(callback));
 }
 
-void Sensor::push_new_value(float value, int8_t accuracy_decimals) {
-  this->callback_.call(value, accuracy_decimals);
+void Sensor::push_new_value(float value) {
+  this->callback_.call(value);
 }
 std::string Sensor::unit_of_measurement() {
   return "";
@@ -26,6 +26,9 @@ std::string Sensor::icon() {
   return "";
 }
 uint32_t Sensor::update_interval() {
+  return 0;
+}
+int8_t Sensor::accuracy_decimals() {
   return 0;
 }
 

--- a/src/esphomelib/sensor/sensor.h
+++ b/src/esphomelib/sensor/sensor.h
@@ -14,7 +14,7 @@ namespace esphomelib {
 
 namespace sensor {
 
-using sensor_callback_t = std::function<void(float, int8_t)>;
+using sensor_callback_t = std::function<void(float)>;
 
 const std::string UNIT_OF_MEASUREMENT_CELSIUS = "°C";
 const std::string UNIT_OF_MEASUREMENT_PERCENT = "%";
@@ -41,9 +41,8 @@ class Sensor {
    * can later override this accuracy.
    *
    * @param value The floating point value.
-   * @param accuracy_decimals The accuracy in decimal points. The user can customize this.
    */
-  void push_new_value(float value, int8_t accuracy_decimals);
+  void push_new_value(float value);
 
   /** Override this to set the Home Assistant unit of measurement for this sensor.
    *
@@ -64,13 +63,16 @@ class Sensor {
   /// Return with which interval the sensor is polled. Return 0 for non-polling mode.
   virtual uint32_t update_interval();
 
+  /// Return the accuracy in decimals for this sensor.
+  virtual int8_t accuracy_decimals();
+
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
   /// The MQTT sensor class uses this to register itself as a listener for new values.
   void add_new_value_callback(sensor_callback_t callback);
 
  protected:
-  CallbackManager<void(float, int8_t)> callback_{};
+  CallbackManager<void(float)> callback_{};
 };
 
 class PollingSensorComponent : public PollingComponent, public sensor::Sensor {


### PR DESCRIPTION
The previous API for accuracy management wasn't very nice and probably useless. Most sensors have a constant accuracy in decimals so this PR refactors the `accuracy_decimals` into its own API in `Sensor`.

