### PR TITLE
Make esphomelib compatible with the Arduino IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For example, the software for a device with an RGB light using the internal PWM 
 [DHT22](https://www.adafruit.com/product/385) temperature sensor can be as simple as this:
 
 ```cpp
-#include "esphomelib/application.h"
+#include "esphomelib.h"
 
 using namespace esphomelib;
 
@@ -75,8 +75,7 @@ You can find a documentation for the API of this project at [esphomelib.com](htt
 
 ### Setting Up Development Environment
 
->  Note: Developing in the Arduino IDE is currently not possible, but support for this is being looked into. However, 
-> platformio will remain the preferred method.
+#### PlatformIO
 
 esphomelib is made for use with [platformio](http://platformio.org/), an advanced ecosystem for microcontroller
 development. To get started with coding esphomelib applications, you first have to 
@@ -104,6 +103,25 @@ board = nodemcuv2
 
 Finally, create a new source file in the `src/` folder (for example `main.cpp`) and start coding with esphomelib.
 
+#### Arduino IDE
+
+
+##### Installing the esphomelib library
+
+1. Download the latest release from https://github.com/OttoWinter/esphomelib/releases
+2. (In the Arduino IDE) **Sketch > Include Library > Add .ZIP Library... >** select the downloaded file **> Open**
+
+##### Installing library dependencies
+
+Repeat the above steps with the following libraries:
+- https://github.com/marvinroger/async-mqtt-client/releases
+- https://github.com/OttoWinter/ArduinoJson/releases
+- https://github.com/FastLED/FastLED/releases
+- https://github.com/me-no-dev/ESPAsyncWebServer/archive/master.zip
+- https://github.com/me-no-dev/AsyncTCP/archive/master.zip
+
+After installing esphomelib, you will find a variety of example sketches under **File > Examples > esphomelib**.
+
 ### Bare Bones
 
 Before adding all the desired components to your code, there are a few things you need to set up first.
@@ -111,7 +129,7 @@ Before adding all the desired components to your code, there are a few things yo
 Begin with including the library and setting the C++ namespace.
 
 ```cpp
-#include "esphomelib/application.h"
+#include "esphomelib.h"
 
 using namespace esphomelib;
 ```

--- a/examples/custom-bmp180-sensor/custom-bmp180-sensor.cpp
+++ b/examples/custom-bmp180-sensor/custom-bmp180-sensor.cpp
@@ -11,7 +11,7 @@
 //   See  for more information
 // </WARNING>
 
-#include "esphomelib/application.h"
+#include <esphomelib.h>
 #include <Adafruit_BMP085.h>
 
 using namespace esphomelib;

--- a/examples/custom-bmp180-sensor/custom-bmp180-sensor.ino
+++ b/examples/custom-bmp180-sensor/custom-bmp180-sensor.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/examples/dht-dallas-sensors/dht-dallas-sensors.cpp
+++ b/examples/dht-dallas-sensors/dht-dallas-sensors.cpp
@@ -2,7 +2,7 @@
 // Created by Otto Winter on 22.01.18.
 //
 
-#include <esphomelib/application.h>
+#include <esphomelib.h>
 
 using namespace esphomelib;
 

--- a/examples/dht-dallas-sensors/dht-dallas-sensors.ino
+++ b/examples/dht-dallas-sensors/dht-dallas-sensors.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/examples/fan-example/fan-example.cpp
+++ b/examples/fan-example/fan-example.cpp
@@ -2,7 +2,7 @@
 // Created by Otto Winter on 24.01.18.
 //
 
-#include <esphomelib/application.h>
+#include <esphomelib.h>
 
 using namespace esphomelib;
 

--- a/examples/fan-example/fan-example.ino
+++ b/examples/fan-example/fan-example.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/examples/fastled/fastled.cpp
+++ b/examples/fastled/fastled.cpp
@@ -6,8 +6,8 @@
 //  Copyright © 2018 Otto Winter. All rights reserved.
 //
 
-#include "esphomelib/application.h"
-#include "esphomelib/light/light_effect.h"
+#include <esphomelib.h>
+#include <esphomelib/light/light_effect.h>
 
 using namespace esphomelib;
 

--- a/examples/fastled/fastled.ino
+++ b/examples/fastled/fastled.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/examples/i2c-sensors/i2c-sensors.cpp
+++ b/examples/i2c-sensors/i2c-sensors.cpp
@@ -8,7 +8,7 @@
 
 // This class shows you how you can use various i2c sensors with esphomelib
 
-#include "esphomelib/application.h"
+#include <esphomelib.h>
 
 using namespace esphomelib;
 

--- a/examples/i2c-sensors/i2c-sensors.ino
+++ b/examples/i2c-sensors/i2c-sensors.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/examples/lights/lights.cpp
+++ b/examples/lights/lights.cpp
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Otto Winter. All rights reserved.
 //
 
-#include "esphomelib/application.h"
+#include <esphomelib.h>
 
 using namespace esphomelib;
 

--- a/examples/lights/lights.ino
+++ b/examples/lights/lights.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/examples/livingroom/livingroom.cpp
+++ b/examples/livingroom/livingroom.cpp
@@ -2,7 +2,7 @@
 // Created by Otto Winter on 21.01.18.
 //
 
-#include <esphomelib/application.h>
+#include <esphomelib.h>
 
 using namespace esphomelib;
 

--- a/examples/livingroom/livingroom.ino
+++ b/examples/livingroom/livingroom.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/examples/livingroom8266/livingroom8266.cpp
+++ b/examples/livingroom8266/livingroom8266.cpp
@@ -2,7 +2,7 @@
 // Created by Otto Winter on 21.01.18.
 //
 
-#include <esphomelib/application.h>
+#include <esphomelib.h>
 
 using namespace esphomelib;
 

--- a/examples/livingroom8266/livingroom8266.ino
+++ b/examples/livingroom8266/livingroom8266.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/examples/pcf8574/pcf8574.cpp
+++ b/examples/pcf8574/pcf8574.cpp
@@ -3,7 +3,7 @@
 //  Copyright © 2018 Otto Winter. All rights reserved.
 //
 
-#include "esphomelib/application.h"
+#include <esphomelib.h>
 
 using namespace esphomelib;
 

--- a/examples/pcf8574/pcf8574.ino
+++ b/examples/pcf8574/pcf8574.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/examples/switch-binarysensor/switch-binarysensor.cpp
+++ b/examples/switch-binarysensor/switch-binarysensor.cpp
@@ -2,7 +2,7 @@
 // Created by Otto Winter on 22.01.18.
 //
 
-#include <esphomelib/application.h>
+#include <esphomelib.h>
 
 using namespace esphomelib;
 using namespace esphomelib::switch_::ir;

--- a/examples/switch-binarysensor/switch-binarysensor.ino
+++ b/examples/switch-binarysensor/switch-binarysensor.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=esphomelib
+version=1.5.3
+author=Otto Winter <contact@otto-winter.com>
+maintainer=Otto Winter <contact@otto-winter.com>
+sentence=esphomelib is a library designed to greatly simplify your firmware code for ESP32-based devices with full MQTT and Home Assistant support.
+paragraph=
+category=Other
+url=https://github.com/OttoWinter/esphomelib
+architectures=esp32,esp8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/livingroom.cpp>
+src_filter = ${common.src_filter} +<examples/livingroom/livingroom.cpp>
 
 [env:dht-dallas-sensors]
 platform = espressif32
@@ -28,7 +28,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/dht-dallas-sensors.cpp>
+src_filter = ${common.src_filter} +<examples/dht-dallas-sensors/dht-dallas-sensors.cpp>
 
 [env:switch-binarysensor]
 platform = espressif32
@@ -36,7 +36,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/switch-binarysensor.cpp>
+src_filter = ${common.src_filter} +<examples/switch-binarysensor/switch-binarysensor.cpp>
 
 [env:fan-example]
 platform = espressif32
@@ -44,7 +44,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/fan-example.cpp>
+src_filter = ${common.src_filter} +<examples/fan-example/fan-example.cpp>
 
 [env:lights]
 platform = espressif32
@@ -52,7 +52,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/lights.cpp>
+src_filter = ${common.src_filter} +<examples/lights/lights.cpp>
 
 [env:livingroom8266]
 platform = espressif8266
@@ -60,7 +60,7 @@ board = nodemcuv2
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/livingroom8266.cpp>
+src_filter = ${common.src_filter} +<examples/livingroom8266/livingroom8266.cpp>
 
 [env:custombmp180]
 platform = espressif8266
@@ -70,7 +70,7 @@ lib_deps =
     ${common.lib_deps}
     Adafruit BMP085 Library
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/custom-bmp180-sensor.cpp>
+src_filter = ${common.src_filter} +<examples/custom-bmp180-sensor/custom-bmp180-sensor.cpp>
 
 [env:i2c-sensors]
 platform = espressif32
@@ -78,7 +78,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/i2c-sensors.cpp>
+src_filter = ${common.src_filter} +<examples/i2c-sensors/i2c-sensors.cpp>
 
 [env:pcf8574]
 platform = espressif32
@@ -86,7 +86,7 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/pcf8574.cpp>
+src_filter = ${common.src_filter} +<examples/pcf8574/pcf8574.cpp>
 
 [env:fastled]
 platform = espressif32
@@ -94,4 +94,4 @@ board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
-src_filter = ${common.src_filter} +<examples/fastled.cpp>
+src_filter = ${common.src_filter} +<examples/fastled/fastled.cpp>

--- a/src/esphomelib.h
+++ b/src/esphomelib.h
@@ -1,0 +1,1 @@
+#include "esphomelib/application.h"


### PR DESCRIPTION
- Add library.properties file with library metadata.
- Move library source files directly under the `src` subfolder.
- Move each example program to its own folder and add dummy .ino files to make them valid Arduino sketches.
- Update platformio.ini to reflect the new example program locations.
- Add Arduino IDE installation instructions to README.md.
- Update `#include` directives according to new source files location.
- Make all internal `#include` directives relative.
  - This will avoid searching the full include path for the files to avoid filename collisions with other installed libraries.

I've endeavored to make the fewest number of changes possible. The Arduino IDE user experience could be further enhanced by the following additional changes (which are **not** implemented in this pull request):
- Fix warnings that cause compilation to fail for ESP32 when File > Preferences > Compiler warnings is set to "More" or "All" (Arduino core for the ESP32 [sets `-Werror=all` at those warning levels](https://github.com/espressif/arduino-esp32/blob/master/platform.txt#L20-L21))
- Add the file src/esphomelib.h, which simply #includes application.h and #include esphomelib.h from the examples. This will make it more clear which library is being used and avoid possible name collisions with other installed libraries that have a file named application.h.
- Move example code from the .cpp file to the .ino file. Although I did add an explanatory comment to the dummy .ino files, I think it will be a bit confusing for some Arduino users to find the primary file empty.
- Add esphomelib and to the [Arduino Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ) for the easiest possible installation and update of the library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification