### PR TITLE
Fix #55 - Action._next not initialized to nullptr

### DIFF
--- a/src/esphomelib/automation.h
+++ b/src/esphomelib/automation.h
@@ -108,7 +108,7 @@ class Action {
  protected:
   friend ActionList<T>;
 
-  Action<T> *next_;
+  Action<T> *next_ = nullptr;
 };
 
 template<typename T>


### PR DESCRIPTION
Causes play_next() to run off into uninitialized memory on ESP32.