### PR TITLE
Fix panic in binary_sensor template

### DIFF
--- a/src/esphomelib/binary_sensor/template_binary_sensor.h
+++ b/src/esphomelib/binary_sensor/template_binary_sensor.h
@@ -28,7 +28,7 @@ class TemplateBinarySensor : public Component, public BinarySensor {
   float get_setup_priority() const override;
 
  protected:
-  std::function<optional<bool>()> &&f_;
+  std::function<optional<bool>()> f_;
 };
 
 } // namespace binary_sensor


### PR DESCRIPTION
Fixes a panic with the binary_sensor due to a typo in the lambda declaration.

* Fixes [esphomeyaml#74](https://github.com/OttoWinter/esphomeyaml/issues/74).