### PR TITLE
output: configurable default pin state

### DIFF
--- a/src/esphomelib/output/gpio_binary_output_component.cpp
+++ b/src/esphomelib/output/gpio_binary_output_component.cpp
@@ -22,14 +22,15 @@ void GPIOBinaryOutputComponent::write_enabled(bool value) {
 void GPIOBinaryOutputComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up GPIO Binary Output...");
   this->pin_->setup();
-  this->pin_->digital_write(false);
+  this->pin_->digital_write(this->default_pin_high_);
 }
 
 float GPIOBinaryOutputComponent::get_setup_priority() const {
   return setup_priority::HARDWARE;
 }
-GPIOBinaryOutputComponent::GPIOBinaryOutputComponent(GPIOPin *pin)
-  : pin_(pin) { }
+GPIOBinaryOutputComponent::GPIOBinaryOutputComponent(GPIOPin *pin,
+                                                     bool default_pin_high)
+  : pin_(pin), default_pin_high_(default_pin_high) { }
 
 } // namespace output
 

--- a/src/esphomelib/output/gpio_binary_output_component.h
+++ b/src/esphomelib/output/gpio_binary_output_component.h
@@ -30,8 +30,10 @@ class GPIOBinaryOutputComponent : public BinaryOutput, public Component {
   /** Construct the GPIO binary output.
    *
    * @param pin The output pin to use for this output, can be integer or GPIOOutputPin.
+   * @param default_pin_high If true pin will be set high initially, else low.
    */
-  explicit GPIOBinaryOutputComponent(GPIOPin *pin);
+  explicit GPIOBinaryOutputComponent(GPIOPin *pin,
+                                     bool default_pin_high = false);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -46,6 +48,7 @@ class GPIOBinaryOutputComponent : public BinaryOutput, public Component {
 
  protected:
   GPIOPin *pin_;
+  bool default_pin_high_;
 };
 
 } // namespace output


### PR DESCRIPTION
Adds the `default_pin_high` paramater to `GPIOBinaryOutputComponent`'s
constructor with the default value of false. Allows keeping the pin high
if needed during `setup()` (e.g. when using an enable low relay
board).