### PR TITLE
[RFC] application: add critical device mode

### DIFF
--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -1009,8 +1009,11 @@ class Application {
   template<class C>
   C *register_controller(C *c);
 
-  /// Set up all the registered components. Call this at the end of your setup() function.
-  void setup();
+  /** Set up all the registered components. Call this at the end of your setup() function.
+   *
+   * @param critical_device if true setup will not block on `Component.can_proceed() == false`.
+   */
+  void setup(bool critical_device = false);
 
   /// Make a loop iteration. Call this in your loop() function.
   void loop();


### PR DESCRIPTION
Adds the boolean flag `critical_device` to `Application::setup()` which
defaults to false. If set to true, setup will not block on the
components `can_proceed()`, allowing the device to transition to
`loop()` as soon as possible.

My particular use case is to use `esphomelib` to drive a refrigerator keeping it around 10c for cheese aging.  To do this I'd like to be able to run my logic as fast as possible on startup (potentially after a power loss), the blocking on `can_proceed()` would prevent this if the mqtt host or the wifi was down. It appears that the connections still get established when needed during the `loop()` or fails fast, allowing for other logic to run to trigger the relays as needed.