### PR TITLE
Run travis jobs in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ cmake-build-release/
 
 # pyenv
 .python-version
+.clang_complete
+.gcc-flags.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,36 +29,22 @@ python:
   - "2.7"
 install:
   - pip install -U platformio
+cache:
+  directories:
+    - "~/.platformio"
+    - "$TRAVIS_BUILD_DIR/.piolibdeps"
+env:
+  matrix:
+    - BUILD_TARGET=livingroom
+    - BUILD_TARGET=dht-dallas-sensors
+    - BUILD_TARGET=switch-binarysensor
+    - BUILD_TARGET=fan-example
+    - BUILD_TARGET=lights
+    - BUILD_TARGET=livingroom8266
+    - BUILD_TARGET=custombmp180
+    - BUILD_TARGET=i2c-sensors
+    - BUILD_TARGET=pcf8574
+    - BUILD_TARGET=fastled
+
 script:
-  - platformio run -e livingroom
-  - platformio run -e dht-dallas-sensors
-  - platformio run -e switch-binarysensor
-  - platformio run -e fan-example
-  - platformio run -e lights
-  - platformio run -e livingroom8266
-  - platformio run -e custombmp180
-  - platformio run -e i2c-sensors
-  - platformio run -e pcf8574
-  - platformio run -e fastled
-
-# Together:
-# platformio run -e livingroom -e dht-dallas-sensors -e switch-binarysensor -e fan-example -e lights -e livingroom8266 -e custombmp180 -e i2c-sensors -e pcf8574
-
-#
-# Template #2: The project is intended to by used as a library with examples
-#
-
-# language: python
-# python:
-#     - "2.7"
-#
-# env:
-#     - PLATFORMIO_CI_SRC=path/to/test/file.c
-#     - PLATFORMIO_CI_SRC=examples/file.ino
-#     - PLATFORMIO_CI_SRC=path/to/test/directory
-#
-# install:
-#     - pip install -U platformio
-#
-# script:
-#     - platformio ci --lib="." --board=ID_1 --board=ID_2 --board=ID_N
+  - platformio run -e $BUILD_TARGET


### PR DESCRIPTION
This will enable Travis to run different jobs in parallel. 

It speeds up overall testing (from 9 to 3 min), and provides per-job view of status, for easier problem finding.