### PR TITLE
Fix checksum verification for DHT11 sensors

### DIFF
--- a/src/esphomelib/sensor/dht_component.cpp
+++ b/src/esphomelib/sensor/dht_component.cpp
@@ -142,13 +142,8 @@ bool DHTComponent::read_sensor_(float *temperature, float *humidity, bool report
             BYTE_TO_BINARY(data[2]), BYTE_TO_BINARY(data[3]),
             BYTE_TO_BINARY(data[4]));
 
-  uint8_t checksum;
-  if (this->model_ == DHT_MODEL_DHT11)
-    checksum = data[0] + data[2];
-  else
-    checksum = data[0] + data[1] + data[2] + data[3];
-
-  if (checksum != data[4]) {
+  uint8_t checksum = (data[0] + data[1] + data[2] + data[3]) & 0xFF;
+  if (data[4] != checksum) {
     if (report_errors) {
       ESP_LOGE(TAG, "Checksum invalid: %u!=%u", checksum, data[4]);
     }


### PR DESCRIPTION
This PR is meant as a fix for #128. See the issue for more details.

I've found [TinyDHT.cpp @ adafruit/TinyDHT](https://github.com/adafruit/TinyDHT/blob/103fc3f423e71087aaae1a2e8267b9d54fcc6da0/TinyDHT.cpp#L155-L159), which uses a different implementation to check if the read data is valid. It works fine with my DHT11 sensors.

**Attention:** This change is **NOT** tested with DHT21 and DHT22 sensors!