### PR TITLE
Optimize MQTT client memory consumption a bit

### DIFF
--- a/src/esphomelib/mqtt/mqtt_client_component.cpp
+++ b/src/esphomelib/mqtt/mqtt_client_component.cpp
@@ -70,12 +70,14 @@ void MQTTClientComponent::setup() {
     }
     ESP_LOGW(TAG, "MQTT Disconnected: %s.", reason_s);
   });
-  if (this->is_log_message_enabled())
+  if (this->is_log_message_enabled()) {
     global_log_component->add_on_log_callback([this](int level, const char *message) {
       if (this->mqtt_client_.connected() && this->state_ == MQTT_CLIENT_CONNECTED) {
         this->publish(this->log_message_.topic, message, this->log_message_.qos, this->log_message_.retain);
       }
     });
+  }
+
   add_shutdown_hook([this](const char *cause){
     if (!this->shutdown_message_.topic.empty()) {
       yield();
@@ -139,7 +141,8 @@ void MQTTClientComponent::check_connected() {
   for (MQTTSubscription &subscription : this->subscriptions_)
     this->mqtt_client_.subscribe(subscription.topic.c_str(), subscription.qos);
 
-  this->on_connect_.call();
+  for (MQTTComponent *component : this->children_)
+    component->schedule_resend_state();
 }
 
 void MQTTClientComponent::loop() {
@@ -313,9 +316,6 @@ void MQTTClientComponent::publish_json(const std::string &topic, const json_buil
 void MQTTClientComponent::set_log_message_template(MQTTMessage &&message) {
   this->log_message_ = std::move(message);
 }
-void MQTTClientComponent::add_on_connect_callback(std::function<void()> &&callback) {
-  this->on_connect_.add(std::move(callback));
-}
 
 void MQTTClientComponent::on_message(const std::string &topic, const std::string &payload) {
 #ifdef ARDUINO_ARCH_ESP8266
@@ -339,6 +339,9 @@ MQTTMessageTrigger *MQTTClientComponent::make_message_trigger(const std::string 
 }
 void MQTTClientComponent::set_reboot_timeout(uint32_t reboot_timeout) {
   this->reboot_timeout_ = reboot_timeout;
+}
+void MQTTClientComponent::register_mqtt_component(MQTTComponent *component) {
+  this->children_.push_back(component);
 }
 
 #if ASYNC_TCP_SSL_ENABLED

--- a/src/esphomelib/mqtt/mqtt_client_component.h
+++ b/src/esphomelib/mqtt/mqtt_client_component.h
@@ -77,6 +77,8 @@ enum MQTTClientState {
   MQTT_CLIENT_CONNECTED,
 };
 
+class MQTTComponent;
+
 class MQTTClientComponent : public Component {
  public:
   explicit MQTTClientComponent(const MQTTCredentials &credentials, const std::string &topic_prefix);
@@ -189,9 +191,6 @@ class MQTTClientComponent : public Component {
    */
   void publish_json(const std::string &topic, const json_build_t &f, uint8_t qos, bool retain);
 
-  /// Add a callback that will be called every time the MQTT client reconnects.
-  void add_on_connect_callback(std::function<void()> &&callback);
-
   /// Setup the MQTT client, registering a bunch of callbacks and attempting to connect.
   void setup() override;
   /// Reconnect if required
@@ -211,6 +210,8 @@ class MQTTClientComponent : public Component {
   void check_connected();
 
   void set_reboot_timeout(uint32_t reboot_timeout);
+
+  void register_mqtt_component(MQTTComponent *component);
 
  protected:
   /// Reconnect to the MQTT broker if not already connected.
@@ -240,8 +241,8 @@ class MQTTClientComponent : public Component {
 
   std::vector<MQTTSubscription> subscriptions_;
   AsyncMqttClient mqtt_client_;
-  CallbackManager<void()> on_connect_{};
   MQTTClientState state_{MQTT_CLIENT_DISCONNECTED};
+  std::vector<MQTTComponent *> children_;
   uint32_t reboot_timeout_{60000};
   uint32_t connect_begin_;
   uint32_t last_connected_{0};

--- a/src/esphomelib/mqtt/mqtt_component.cpp
+++ b/src/esphomelib/mqtt/mqtt_component.cpp
@@ -11,6 +11,7 @@
 #include "esphomelib/log.h"
 #include "esphomelib/helpers.h"
 #include "esphomelib/application.h"
+#include "mqtt_component.h"
 
 ESPHOMELIB_NAMESPACE_BEGIN
 
@@ -165,9 +166,7 @@ void MQTTComponent::setup_() {
   if (this->is_discovery_enabled())
     this->send_discovery_();
 
-  global_mqtt_client->add_on_connect_callback([this]() {
-    this->resend_state_ = true;
-  });
+  global_mqtt_client->register_mqtt_component(this);
 }
 void MQTTComponent::loop_() {
   this->loop_internal();
@@ -184,6 +183,9 @@ void MQTTComponent::loop_() {
 
     this->resend_state_ = false;
   }
+}
+void MQTTComponent::schedule_resend_state() {
+  this->resend_state_ = true;
 }
 
 } // namespace mqtt

--- a/src/esphomelib/mqtt/mqtt_component.h
+++ b/src/esphomelib/mqtt/mqtt_component.h
@@ -79,6 +79,9 @@ class MQTTComponent : public Component {
    */
   void set_availability(std::string topic, std::string payload_available, std::string payload_not_available);
   void disable_availability();
+
+  /// Internal method for the MQTT client base to schedule a resend of the state on reconnect.
+  void schedule_resend_state();
   
  protected:
   /// Helper method to get the discovery topic for this component.


### PR DESCRIPTION
Pointers cost less memory than full `std::function`s. Probably just a microoptimization, but it's good that the MQTT client knows about all its child components.