### PR TITLE
Fix binary sensor heartbeat filter

### DIFF
--- a/src/esphomelib/binary_sensor/binary_sensor.cpp
+++ b/src/esphomelib/binary_sensor/binary_sensor.cpp
@@ -18,11 +18,6 @@ void BinarySensor::add_on_state_callback(binary_callback_t &&callback) {
 }
 
 void BinarySensor::publish_state(bool state) {
-  if (!this->is_first_raw_ && this->last_raw_ == state)
-    return;
-  this->is_first_raw_ = false;
-  this->last_raw_ = state;
-
   if (this->filter_list_ == nullptr) {
     this->send_value_(state);
   } else {
@@ -31,10 +26,6 @@ void BinarySensor::publish_state(bool state) {
 
 }
 void BinarySensor::send_value_(bool state) {
-  if (this->last_value_ == state)
-    return;
-  this->last_value_ = state;
-
   this->value = state;
   this->state_callback_.call(state);
 }

--- a/src/esphomelib/binary_sensor/binary_sensor.h
+++ b/src/esphomelib/binary_sensor/binary_sensor.h
@@ -88,8 +88,6 @@ class BinarySensor : public Nameable {
   /// Get the default device class for this sensor, or empty string for no default.
   virtual std::string device_class();
 
-  bool last_raw_, is_first_raw_{true};
-  bool last_value_;
   CallbackManager<void(bool)> state_callback_{};
   optional<std::string> device_class_{}; ///< Stores the override of the device class
   Filter *filter_list_{nullptr};

--- a/src/esphomelib/binary_sensor/esp32_touch_binary_sensor.cpp
+++ b/src/esphomelib/binary_sensor/esp32_touch_binary_sensor.cpp
@@ -99,7 +99,12 @@ void ESP32TouchComponent::loop() {
       touch_pad_read(child->get_touch_pad(), &value);
     }
 
-    child->publish_state(value < child->get_threshold());
+    bool new_state = value < child->get_threshold();
+    if (child->is_first_state_ || child->last_state_ != new_state) {
+      child->is_first_state_ = false;
+      child->last_state_ = new_state;
+      child->publish_state(new_state);
+    }
 
     if (this->setup_mode_) {
       ESP_LOGD(TAG, "Touch Pad '%s' (T%u): %u", child->get_name().c_str(), child->get_touch_pad(), value);

--- a/src/esphomelib/binary_sensor/esp32_touch_binary_sensor.h
+++ b/src/esphomelib/binary_sensor/esp32_touch_binary_sensor.h
@@ -200,8 +200,12 @@ class ESP32TouchBinarySensor : public BinarySensor {
   uint16_t get_threshold() const;
 
  protected:
+  friend ESP32TouchComponent;
+
   touch_pad_t touch_pad_;
   uint16_t threshold_;
+  bool last_state_{false};
+  bool is_first_state_{true};
 };
 
 } // namespace binary_sensor

--- a/src/esphomelib/binary_sensor/gpio_binary_sensor_component.cpp
+++ b/src/esphomelib/binary_sensor/gpio_binary_sensor_component.cpp
@@ -19,10 +19,16 @@ static const char *TAG = "binary_sensor.gpio";
 void GPIOBinarySensorComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up GPIO binary sensor '%s'...", this->name_.c_str());
   this->pin_->setup();
+  this->last_state_ = this->pin_->digital_read();
+  this->publish_state(this->last_state_);
 }
 
 void GPIOBinarySensorComponent::loop() {
-  this->publish_state(this->pin_->digital_read());
+  bool new_state = this->pin_->digital_read();
+  if (this->last_state_ != new_state) {
+    this->last_state_ = new_state;
+    this->publish_state(new_state);
+  }
 }
 
 float GPIOBinarySensorComponent::get_setup_priority() const {
@@ -30,7 +36,9 @@ float GPIOBinarySensorComponent::get_setup_priority() const {
 }
 
 GPIOBinarySensorComponent::GPIOBinarySensorComponent(const std::string &name, GPIOPin *pin)
-  : BinarySensor(name), pin_(pin) { }
+  : BinarySensor(name), pin_(pin) {
+
+}
 
 } // namespace binary_sensor
 

--- a/src/esphomelib/binary_sensor/gpio_binary_sensor_component.h
+++ b/src/esphomelib/binary_sensor/gpio_binary_sensor_component.h
@@ -40,6 +40,7 @@ class GPIOBinarySensorComponent : public BinarySensor, public Component {
 
  protected:
   GPIOPin *pin_;
+  bool last_state_{false};
 };
 
 } // namespace binary_sensor

--- a/src/esphomelib/binary_sensor/template_binary_sensor.cpp
+++ b/src/esphomelib/binary_sensor/template_binary_sensor.cpp
@@ -23,7 +23,12 @@ TemplateBinarySensor::TemplateBinarySensor(const std::string &name)
 void TemplateBinarySensor::loop() {
   auto s = this->f_();
   if (s.has_value()) {
-    this->publish_state(*s);
+    bool new_state = *s;
+    if (this->is_first_state_ || this->last_state_ != new_state) {
+      this->is_first_state_ = false;
+      this->last_state_ = new_state;
+      this->publish_state(new_state);
+    }
   }
 }
 float TemplateBinarySensor::get_setup_priority() const {

--- a/src/esphomelib/binary_sensor/template_binary_sensor.h
+++ b/src/esphomelib/binary_sensor/template_binary_sensor.h
@@ -32,6 +32,8 @@ class TemplateBinarySensor : public Component, public BinarySensor {
 
  protected:
   std::function<optional<bool>()> f_;
+  bool last_state_{false};
+  bool is_first_state_{true};
 };
 
 } // namespace binary_sensor

--- a/src/esphomelib/display/nextion.cpp
+++ b/src/esphomelib/display/nextion.cpp
@@ -268,7 +268,9 @@ void Nextion::set_component_text_printf(const char *component, const char *forma
 }
 
 void NextionTouchComponent::process(uint8_t page_id, uint8_t component_id, bool on) {
-  if (this->page_id_ == page_id && this->component_id_ == component_id) {
+  if (this->page_id_ == page_id && this->component_id_ == component_id &&
+      this->last_state_ != on) {
+    this->last_state_ = on;
     this->publish_state(on);
   }
 }

--- a/src/esphomelib/display/nextion.h
+++ b/src/esphomelib/display/nextion.h
@@ -81,6 +81,7 @@ class NextionTouchComponent : public binary_sensor::BinarySensor {
  protected:
   uint8_t page_id_;
   uint8_t component_id_;
+  bool last_state_{false};
 };
 
 } // namespace display


### PR DESCRIPTION
The old "only send state if it's different from the last sent one" was interfering with the heartbeat filter. This change moves that logic into each component. It's a bit harder to maintain, but is probably the solution that is the most flexible.