### PR TITLE
Fix SSD1306 reset order for i2c

### DIFF
--- a/src/esphomelib/display/ssd1306.h
+++ b/src/esphomelib/display/ssd1306.h
@@ -50,6 +50,7 @@ class SSD1306 : public PollingComponent, public DisplayBuffer {
  protected:
   virtual void command(uint8_t value) = 0;
   virtual void write_display_data() = 0;
+  void init_reset_();
 
   bool is_sh1106_() const;
 


### PR DESCRIPTION
See OttoWinter/esphomeyaml#128

Apparently, the i2c version only accepts *any* i2c communication after the reset pin is pulled high.