### PR TITLE
Fix light color not changing when also changing effect

### DIFF
--- a/src/esphomelib/light/light_state.cpp
+++ b/src/esphomelib/light/light_state.cpp
@@ -160,11 +160,13 @@ void LightState::parse_json(const JsonObject &root) {
   } else if (root.containsKey("transition")) {
     auto length = uint32_t(float(root["transition"]) * 1000);
     this->start_transition(v, length);
-  } else if (root.containsKey("effect")) {
-    const char *effect = root["effect"];
-    this->start_effect(effect);
   } else {
     this->start_default_transition(v);
+  }
+
+  if (root.containsKey("effect")) {
+    const char *effect = root["effect"];
+    this->start_effect(effect);
   }
 }
 


### PR DESCRIPTION
Designed to fix: #167 but also seems to fix #166 (because we're now starting a transition back to the normal color lights, if we reset the effect.)

Previously:
```{"state": "ON", "color": {"r": 0, "g": 0, "b": 255}, "brightness": 200, "effect": "None"}```
If we had this payload, only the effect would be set (e.g. to none) but not the actual colors provided.
Regardless of how many times this was sent (or if the effect was already "None").
Now we're starting the effect (in case of "None", we're stopping the effect) and are then also setting the colors (e.g. starting the transition).

This is needed because if we stop the effect (setting to "None"), the previous colors from the effect stayed (e.g. if we had been using "Strobe", the colors could either be 255, 255, 255 or 0, 0, 0).
This will fix #166 

In order to fix #167 we also want to stop the effect but also start the transition to the normal colors, not just leave them out, because that would make the whole "color" part of the payload useless, if an effect is provided in the same payload.

So the fix for the issue is the same.
Since I'm not an experienced C++ developer at all (just started for esphomelib actually), I can't really say if this fix is considered "clean" and you might come up with a better solution.
But I can say that this fix was tested and doesn't seem to have any side effects at all. 