### PR TITLE
Fix pulse counter counting inverted on ESP8266

### DIFF
--- a/src/esphomelib/sensor/pulse_counter.cpp
+++ b/src/esphomelib/sensor/pulse_counter.cpp
@@ -72,7 +72,7 @@ bool PulseCounterBase::pulse_counter_setup_() {
 }
 pulse_counter_t PulseCounterBase::read_raw_value_() {
   pulse_counter_t counter = this->counter_;
-  pulse_counter_t ret = this->last_value_ - counter;
+  pulse_counter_t ret = counter - this->last_value_;
   this->last_value_ = counter;
   return ret;
 }


### PR DESCRIPTION
## Description:

The ESP8266 pulse counter implementation was counting in the wrong direction.

**Related issue (if applicable):** fixes https://github.com/OttoWinter/esphomeyaml/issues/163

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
