### PR TITLE
Rework OTA to be more stable

### DIFF
--- a/examples/dht-dallas-sensors/dht-dallas-sensors.cpp
+++ b/examples/dht-dallas-sensors/dht-dallas-sensors.cpp
@@ -27,7 +27,6 @@ void setup() {
   auto *ota = App.init_ota();
   ota->set_auth_plaintext_password("PASSWORD"); // set an optional password
   ota->set_port(3232); // This is the default for ESP32
-  ota->set_hostname("custom-hostname"); // manually set the hostname
   ota->start_safe_mode();
 
   auto *dallas = App.make_dallas_component(15);

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ platform = espressif32
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
-build_flags = ${common.build_flags}
+build_flags = ${common.build_flags} -DUSE_NEW_OTA
 src_filter = ${common.src_filter} +<examples/livingroom/livingroom.cpp>
 
 [env:dht-dallas-sensors]

--- a/src/esphomelib/application.cpp
+++ b/src/esphomelib/application.cpp
@@ -296,9 +296,7 @@ WiFiComponent *Application::get_wifi() const {
 
 #ifdef USE_OTA
 OTAComponent *Application::init_ota() {
-  auto *ota = new OTAComponent();
-  ota->set_hostname(this->wifi_->get_hostname());
-  return this->register_component(ota);
+  return this->register_component(new OTAComponent());
 }
 #endif
 

--- a/src/esphomelib/helpers.cpp
+++ b/src/esphomelib/helpers.cpp
@@ -16,6 +16,7 @@
 #include "esphomelib/log.h"
 #include "esphomelib/esphal.h"
 #include "esphomelib/espmath.h"
+#include "esphomelib/status_led.h"
 
 ESPHOMELIB_NAMESPACE_BEGIN
 
@@ -213,6 +214,10 @@ void reboot(const char *cause) {
   ESP_LOGI(TAG, "Forcing a reboot... Cause: '%s'", cause);
   run_shutdown_hooks(cause);
   ESP.restart();
+  // restart() doesn't always end execution
+  while (true) {
+    yield();
+  }
 }
 void add_shutdown_hook(std::function<void(const char *)> &&f) {
   shutdown_hooks.add(std::move(f));
@@ -221,6 +226,10 @@ void safe_reboot(const char *cause) {
   ESP_LOGI(TAG, "Rebooting safely... Cause: '%s'", cause);
   run_safe_shutdown_hooks(cause);
   ESP.restart();
+  // restart() doesn't always end execution
+  while (true) {
+    yield();
+  }
 }
 void add_safe_shutdown_hook(std::function<void(const char *)> &&f) {
   safe_shutdown_hooks.add(std::move(f));
@@ -298,6 +307,13 @@ uint8_t reverse_bits_8(uint8_t x) {
 
 uint16_t reverse_bits_16(uint16_t x) {
   return uint16_t(reverse_bits_8(x & 0xFF) << 8) | uint16_t(reverse_bits_8(x >> 8));
+}
+void tick_status_led() {
+#ifdef USE_STATUS_LED
+  if (global_status_led != nullptr) {
+    global_status_led->loop_();
+  }
+#endif
 }
 
 template<uint32_t>

--- a/src/esphomelib/helpers.h
+++ b/src/esphomelib/helpers.h
@@ -40,6 +40,8 @@ extern const char *HOSTNAME_CHARACTER_WHITELIST;
 /// Gets the MAC address as a string, this can be used as way to identify this ESP32.
 std::string get_mac_address();
 
+void tick_status_led();
+
 /// Constructs a hostname by concatenating base, a hyphen, and the MAC address.
 std::string generate_hostname(const std::string &base);
 
@@ -53,13 +55,13 @@ std::string truncate_string(const std::string &s, size_t length);
 bool is_empty(const IPAddress &address);
 
 /// Force a shutdown (and reboot) of the ESP, calling any registered shutdown hooks.
-void reboot(const char *cause);
+void reboot(const char *cause) __attribute__ ((noreturn));
 
 /// Add a shutdown callback.
 void add_shutdown_hook(std::function<void(const char *)> &&f);
 
 /// Create a safe shutdown (and reboot) of the ESP, calling any registered shutdown and safe shutdown hooks.
-void safe_reboot(const char *cause);
+void safe_reboot(const char *cause) __attribute__ ((noreturn));
 
 /// Run shutdown hooks.
 void run_shutdown_hooks(const char *cause);

--- a/src/esphomelib/ota_component.cpp
+++ b/src/esphomelib/ota_component.cpp
@@ -12,15 +12,28 @@
 #include "esphomelib/helpers.h"
 #include "esphomelib/wifi_component.h"
 #include "esphomelib/status_led.h"
-#include "esphomelib/defines.h"
+
+#include <cstdio>
 #include <ArduinoOTA.h>
+#include <StreamString.h>
+
+#ifdef ARDUINO_ARCH_ESP32
+#include <ESPmDNS.h>
+#endif
+#ifdef ARDUINO_ARCH_ESP8266
+#include <ESP8266mDNS.h>
+#endif
 
 ESPHOMELIB_NAMESPACE_BEGIN
 
 static const char *TAG = "ota";
 #ifdef ARDUINO_ARCH_ESP32
-  static const char *PREF_TAG = "ota"; ///< Tag for preferences.
-  static const char *PREF_SAFE_MODE_COUNTER_KEY = "safe_mode";
+static const char *PREF_TAG = "ota"; ///< Tag for preferences.
+static const char *PREF_SAFE_MODE_COUNTER_KEY = "safe_mode";
+#endif
+
+#ifdef USE_NEW_OTA
+uint8_t OTA_VERSION_1_0 = 1;
 #endif
 
 void OTAComponent::setup() {
@@ -29,10 +42,20 @@ void OTAComponent::setup() {
   this->server_ = new WiFiServer(this->port_);
   this->server_->begin();
 
-  if (!this->hostname_.empty()) {
-    ESP_LOGCONFIG(TAG, "    hostname: '%s'", this->hostname_.c_str());
-    ArduinoOTA.setHostname(this->hostname_.c_str());
-  }
+#ifdef USE_NEW_OTA
+  MDNS.begin(global_wifi_component->get_hostname().c_str());
+  MDNS.enableArduino(this->port_, !this->password_.empty());
+
+#ifdef ARDUINO_ARCH_ESP32
+  add_shutdown_hook([this](const char *cause) {
+    if (strcmp(cause, "ota") != 0) {
+      this->server_->close();
+      MDNS.end();
+    }
+  });
+#endif
+#else
+  ArduinoOTA.setHostname(global_wifi_component->get_hostname().c_str());
   ArduinoOTA.setPort(this->port_);
   switch (this->auth_type_) {
     case PLAINTEXT: {
@@ -105,13 +128,8 @@ void OTAComponent::setup() {
     this->status_momentary_error("onerror", 5000);
   });
   ArduinoOTA.begin();
-
-#ifdef ARDUINO_ARCH_ESP32
-  add_shutdown_hook([](const char *cause) {
-    if (strcmp(cause, "ota") != 0)
-      ArduinoOTA.end();
-  });
 #endif
+
 
   if (this->has_safe_mode_) {
     add_safe_shutdown_hook([this](const char *cause) {
@@ -127,15 +145,15 @@ void OTAComponent::setup() {
 }
 
 void OTAComponent::loop() {
+#ifdef USE_NEW_OTA
+  this->handle_();
+#else
   do {
     ArduinoOTA.handle();
-#ifdef USE_STATUS_LED
-    if (global_status_led != nullptr) {
-      global_status_led->loop_();
-    }
-#endif
+    tick_status_led();
     yield();
   } while (this->ota_triggered_);
+#endif
 
   if (this->has_safe_mode_ && (millis() - this->safe_mode_start_time_) > this->safe_mode_enable_time_) {
     this->has_safe_mode_ = false;
@@ -145,14 +163,264 @@ void OTAComponent::loop() {
   }
 }
 
-OTAComponent::OTAComponent(uint16_t port, std::string hostname)
-    : port_(port), hostname_(std::move(hostname)), auth_type_(OPEN), server_(nullptr) {
+#ifdef USE_NEW_OTA
+void OTAComponent::handle_() {
+  OTAResponseTypes error_code = OTA_RESPONSE_ERROR_UNKNOWN;
+  bool update_started = false;
+  uint32_t total = 0;
+  uint32_t last_progress = 0;
+  uint8_t buf[1024];
+  char *sbuf = reinterpret_cast<char *>(buf);
+  uint32_t ota_size;
+  uint8_t ota_features;
+
+  if (!this->client_.connected()) {
+    this->client_ = this->server_->available();
+  }
+
+  if (!this->client_.connected())
+    return;
+
+  ESP_LOGD(TAG, "Starting OTA process...");
+  this->status_set_warning();
+#ifdef USE_STATUS_LED
+  global_state |= STATUS_LED_WARNING;
+#endif
+
+  if (!this->wait_receive_(buf, 5)) {
+    ESP_LOGW(TAG, "Reading magic bytes failed!");
+    goto error;
+  }
+  // 0x6C, 0x26, 0xF7, 0x5C, 0x45
+  if (buf[0] != 0x6C || buf[1] != 0x26 || buf[2] != 0xF7 || buf[3] != 0x5C || buf[4] != 0x45) {
+    ESP_LOGW(TAG, "Magic bytes do not match! 0x%02X-0x%02X-0x%02X-0x%02X-0x%02X",
+             buf[0], buf[1], buf[2], buf[3], buf[4]);
+    error_code = OTA_RESPONSE_ERROR_MAGIC;
+    goto error;
+  }
+
+  // Send OK and version - 2 bytes
+  this->client_.write(OTA_RESPONSE_OK);
+  this->client_.write(OTA_VERSION_1_0);
+
+  // Read features - 1 byte
+  if (!this->wait_receive_(buf, 1)) {
+    ESP_LOGW(TAG, "Reading features failed!");
+    goto error;
+  }
+  ota_features = buf[0];
+  ESP_LOGV(TAG, "OTA features is 0x%02X", ota_features);
+
+  // Acknowledge header - 1 byte
+  this->client_.write(OTA_RESPONSE_HEADER_OK);
+
+  if (!this->password_.empty()) {
+    this->client_.write(OTA_RESPONSE_REQUEST_AUTH);
+    MD5Builder md5_builder{};
+    md5_builder.begin();
+    sprintf(sbuf, "%08X", random_uint32());
+    md5_builder.add(sbuf);
+    md5_builder.calculate();
+    md5_builder.getChars(sbuf);
+    ESP_LOGV(TAG, "Auth: Nonce is %s", sbuf);
+
+    // Send nonce, 32 bytes hex MD5
+    if (this->client_.write(sbuf, 32) != 32) {
+      ESP_LOGW(TAG, "Auth: Writing nonce failed!");
+      goto error;
+    }
+
+    // prepare challenge
+    md5_builder.begin();
+    md5_builder.add(this->password_.c_str());
+    // add nonce
+    md5_builder.add(sbuf);
+
+    // Receive cnonce, 32 bytes hex MD5
+    if (!this->wait_receive_(buf, 32)) {
+      ESP_LOGW(TAG, "Auth: Reading cnonce failed!");
+      goto error;
+    }
+    sbuf[32] = '\0';
+    ESP_LOGV(TAG, "Auth: CNonce is %s", sbuf);
+    // add cnonce
+    md5_builder.add(sbuf);
+
+    // calculate result
+    md5_builder.calculate();
+    md5_builder.getChars(sbuf);
+    ESP_LOGV(TAG, "Auth: Result is %s", sbuf);
+
+    // Receive result, 32 bytes hex MD5
+    if (!this->wait_receive_(buf + 64, 32)) {
+      ESP_LOGW(TAG, "Auth: Reading response failed!");
+      goto error;
+    }
+    sbuf[64 + 32] = '\0';
+    ESP_LOGV(TAG, "Auth: Response is %s", sbuf + 64);
+
+    bool matches = true;
+    for (uint8_t i = 0; i < 32; i++)
+      matches = matches && buf[i] == buf[64 + i];
+
+    if (!matches) {
+      ESP_LOGW(TAG, "Auth failed! Passwords do not match!");
+      error_code = OTA_RESPONSE_ERROR_AUTH_INVALID;
+      goto error;
+    }
+  }
+
+  // Acknowledge auth OK - 1 byte
+  this->client_.write(OTA_RESPONSE_AUTH_OK);
+
+  // Read size, 4 bytes MSB first
+  if (!this->wait_receive_(buf, 4)) {
+    ESP_LOGW(TAG, "Reading size failed!");
+    goto error;
+  }
+  ota_size = 0;
+  for (uint8_t i = 0; i < 4; i++) {
+    ota_size <<= 8;
+    ota_size |= buf[i];
+  }
+  ESP_LOGV(TAG, "OTA size is %u bytes", ota_size);
+
+  if (!Update.begin(ota_size, U_FLASH)) {
+#ifdef ARDUINO_ARCH_ESP8266
+    StreamString ss;
+    Update.printError(ss);
+    if (ss.indexOf("Invalid bootstrapping") != -1) {
+      error_code = OTA_RESPONSE_ERROR_INVALID_BOOTSTRAPPING;
+      goto error;
+    }
+#endif
+    ESP_LOGW(TAG, "Preparing OTA partition failed! Is the binary too big?");
+    error_code = OTA_RESPONSE_ERROR_UPDATE_PREPARE;
+    goto error;
+  }
+  update_started = true;
+
+  // Acknowledge prepare OK - 1 byte
+  this->client_.write(OTA_RESPONSE_UPDATE_PREPARE_OK);
+
+  // Read binary MD5, 32 bytes
+  if (!this->wait_receive_(buf, 32)) {
+    ESP_LOGW(TAG, "Reading binary MD5 checksum failed!");
+    goto error;
+  }
+  sbuf[32] = '\0';
+  ESP_LOGV(TAG, "Update: Binary MD5 is %s", sbuf);
+  Update.setMD5(sbuf);
+
+  // Acknowledge MD5 OK - 1 byte
+  this->client_.write(OTA_RESPONSE_BIN_MD5_OK);
+
+  while (!Update.isFinished()) {
+    size_t available = this->wait_receive_(buf, 0);
+    if (!available) {
+      goto error;
+    }
+
+    uint32_t written = Update.write(buf, available);
+    if (written != available) {
+      ESP_LOGW(TAG, "Error writing binary data to flash: %u != %d!", written, available);
+      error_code = OTA_RESPONSE_ERROR_WRITING_FLASH;
+      goto error;
+    }
+    total += written;
+
+    uint32_t now = millis();
+    if (now - last_progress > 1000) {
+      last_progress = now;
+      float percentage = (total * 100.0f) / ota_size;
+      ESP_LOGD(TAG, "OTA in progress: %0.1f%%", percentage);
+    }
+  }
+
+  // Acknowledge receive OK - 1 byte
+  this->client_.write(OTA_RESPONSE_RECEIVE_OK);
+
+  if (!Update.end()) {
+    error_code = OTA_RESPONSE_ERROR_UPDATE_END;
+    goto error;
+  }
+
+  // Acknowledge Update end OK - 1 byte
+  this->client_.write(OTA_RESPONSE_UPDATE_END_OK);
+  this->client_.flush();
+  this->client_.stop();
+  delay(10);
+  ESP_LOGI(TAG, "OTA update finished!");
+  this->status_clear_warning();
+  delay(100);
+  safe_reboot("ota");
+
+  error:
+  if (update_started) {
+    StreamString ss;
+    Update.printError(ss);
+    ESP_LOGW(TAG, "Update end failed! Error: %s", ss.c_str());
+  }
+  if (this->client_.connected()) {
+    this->client_.write(error_code);
+    this->client_.flush();
+  }
+  this->client_.stop();
+#ifdef ARDUINO_ARCH_ESP32
+  if (update_started) {
+    Update.abort();
+  }
+#endif
+  this->status_momentary_error("onerror", 5000);
+}
+
+size_t OTAComponent::wait_receive_(uint8_t *buf, size_t bytes) {
+  size_t available = 0;
+  uint32_t start = millis();
+  do {
+    tick_status_led();
+    if (!this->client_.connected()) {
+      ESP_LOGW(TAG, "Error client disconnected while receiving data!");
+      return 0;
+    }
+    int availi = this->client_.available();
+    if (availi < 0) {
+      ESP_LOGW(TAG, "Error reading data!");
+      return 0;
+    }
+    uint32_t now = millis();
+    if (availi == 0 && now - start > 5000) {
+      ESP_LOGW(TAG, "Timeout waiting for data!");
+      return 0;
+    }
+    available = size_t(availi);
+    yield();
+  } while (bytes == 0 ? available == 0 : available < bytes);
+
+  if (bytes == 0)
+    bytes = std::min(available, size_t(1024));
+
+  int res = this->client_.read(buf, bytes);
+
+  if (res != int(bytes)) {
+    ESP_LOGW(TAG, "Error reading binary data: %d (%u)!", res, bytes);
+    return 0;
+  }
+
+  return bytes;
+}
+#endif
+
+OTAComponent::OTAComponent(uint16_t port)
+    : port_(port) {
 
 }
 
-void OTAComponent::set_auth_open() {
-  this->auth_type_ = OPEN;
+#ifdef USE_NEW_OTA
+void OTAComponent::set_auth_password(const std::string &password) {
+  this->password_ = password;
 }
+#else
 void OTAComponent::set_auth_plaintext_password(const std::string &password) {
   this->auth_type_ = PLAINTEXT;
   this->password_ = password;
@@ -161,6 +429,8 @@ void OTAComponent::set_auth_password_hash(const std::string &hash) {
   this->auth_type_ = HASH;
   this->password_ = hash;
 }
+#endif
+
 float OTAComponent::get_setup_priority() const {
   return setup_priority::MQTT_CLIENT + 1.0f;
 }
@@ -169,12 +439,6 @@ uint16_t OTAComponent::get_port() const {
 }
 void OTAComponent::set_port(uint16_t port) {
   this->port_ = port;
-}
-const std::string &OTAComponent::get_hostname() const {
-  return this->hostname_;
-}
-void OTAComponent::set_hostname(const std::string &hostname) {
-  this->hostname_ = sanitize_hostname(hostname);
 }
 void OTAComponent::start_safe_mode(uint8_t num_attempts, uint32_t enable_time) {
   this->has_safe_mode_ = true;
@@ -189,7 +453,6 @@ void OTAComponent::start_safe_mode(uint8_t num_attempts, uint32_t enable_time) {
     this->clean_rtc();
 
     ESP_LOGE(TAG, "Boot loop detected. Proceeding to safe mode.");
-    assert(global_wifi_component != nullptr);
 
 #ifdef USE_STATUS_LED
     if (global_status_led != nullptr) {
@@ -201,11 +464,7 @@ void OTAComponent::start_safe_mode(uint8_t num_attempts, uint32_t enable_time) {
     while (!global_wifi_component->can_proceed()) {
       yield();
       global_wifi_component->loop_();
-#ifdef USE_STATUS_LED
-      if (global_status_led != nullptr) {
-        global_status_led->loop_();
-      }
-#endif
+      tick_status_led();
     }
     this->setup_();
 

--- a/src/esphomelib/ota_component.h
+++ b/src/esphomelib/ota_component.h
@@ -11,6 +11,7 @@
 
 #include "esphomelib/component.h"
 #include <WiFiServer.h>
+#include <WiFiClient.h>
 
 #ifdef ARDUINO_ARCH_ESP32
   #define OTA_DEFAULT_PORT 3232

--- a/src/esphomelib/ota_component.h
+++ b/src/esphomelib/ota_component.h
@@ -5,12 +5,12 @@
 #ifndef ESPHOMELIB_OTA_COMPONENT_H
 #define ESPHOMELIB_OTA_COMPONENT_H
 
-#include <WiFiServer.h>
-
-#include "esphomelib/component.h"
 #include "esphomelib/defines.h"
 
 #ifdef USE_OTA
+
+#include "esphomelib/component.h"
+#include <WiFiServer.h>
 
 #ifdef ARDUINO_ARCH_ESP32
   #define OTA_DEFAULT_PORT 3232
@@ -21,38 +21,66 @@
 
 ESPHOMELIB_NAMESPACE_BEGIN
 
+#ifdef USE_NEW_OTA
+enum OTAResponseTypes {
+  OTA_RESPONSE_OK = 0,
+  OTA_RESPONSE_REQUEST_AUTH = 1,
+
+  OTA_RESPONSE_HEADER_OK = 64,
+  OTA_RESPONSE_AUTH_OK = 65,
+  OTA_RESPONSE_UPDATE_PREPARE_OK = 66,
+  OTA_RESPONSE_BIN_MD5_OK = 67,
+  OTA_RESPONSE_RECEIVE_OK = 68,
+  OTA_RESPONSE_UPDATE_END_OK = 69,
+
+  OTA_RESPONSE_ERROR_MAGIC = 128,
+  OTA_RESPONSE_ERROR_UPDATE_PREPARE = 129,
+  OTA_RESPONSE_ERROR_AUTH_INVALID = 130,
+  OTA_RESPONSE_ERROR_WRITING_FLASH = 131,
+  OTA_RESPONSE_ERROR_UPDATE_END = 132,
+  OTA_RESPONSE_ERROR_INVALID_BOOTSTRAPPING = 133,
+  OTA_RESPONSE_ERROR_UNKNOWN = 255,
+};
+
+extern uint8_t OTA_VERSION_1_0;
+#endif
+
 /// OTAComponent provides a simple way to integrate Over-the-Air updates into your app using ArduinoOTA.
 class OTAComponent : public Component {
  public:
   /** Construct an OTAComponent. Defaults to no authentication.
    *
    * @param port The port ArduinoOTA will listen on.
-   * @param hostname The hostname ArduinoOTA will advertise.
    */
-  explicit OTAComponent(uint16_t port = OTA_DEFAULT_PORT, std::string hostname = "");
+  explicit OTAComponent(uint16_t port = OTA_DEFAULT_PORT);
 
-  /// Set ArduinoOTA to accept updates without authentication.
-  void set_auth_open();
-
-  /** Set a plaintext password that ArduinoOTA will use for authentication.
+#ifdef USE_NEW_OTA
+  /** Set a plaintext password that OTA will use for authentication.
    *
-   * Note: theoretically this password can be read from ROM by an intruder.
+   * Warning: This password will be stored in plaintext in the ROM and can be read
+   * by intruders. It is however secured somewhat secure again MITM attacks (attackers
+   * could still modify the binary while you're sending it, but they can't start OTA processes
+   * themselves.)
    *
    * @param password The plaintext password.
    */
+  void set_auth_password(const std::string &password);
+#else
+  /** Set a plaintext password for legacy OTA.
+   *
+   * @param password The password
+   */
   void set_auth_plaintext_password(const std::string &password);
 
-  /** Set a MD5 password hash that ArduinoOTA will use for authentication.
+  /** Set a hashed password for legacy OTA.
    *
-   * @param hash The MD5 hash of the password.
+   * @param password The MD5 password hash.
    */
   void set_auth_password_hash(const std::string &hash);
+#endif
 
   /// Manually set the port OTA should listen on.
   void set_port(uint16_t port);
-
-  /// Set the hostname advertised with mDNS. Empty for default hostname.
-  void set_hostname(const std::string &hostname);
 
   /** Start OTA safe mode. When called at startup, this method will automatically detect boot loops.
    *
@@ -70,12 +98,9 @@ class OTAComponent : public Component {
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
-
   void setup() override;
   float get_setup_priority() const override;
   void loop() override;
-
-  const std::string &get_hostname() const;
 
   uint16_t get_port() const;
 
@@ -85,14 +110,24 @@ class OTAComponent : public Component {
   void write_rtc_(uint8_t val);
   uint8_t read_rtc_();
 
-  enum { OPEN, PLAINTEXT, HASH } auth_type_;
+#ifdef USE_NEW_OTA
+  void handle_();
+  size_t wait_receive_(uint8_t *buf, size_t bytes);
+#else
+  enum { OPEN, PLAINTEXT, HASH } auth_type_{OPEN};
+#endif
 
   std::string password_;
 
   uint16_t port_;
-  std::string hostname_;
-  WiFiServer *server_;
-  bool ota_triggered_{false}; ///< stores whether OTA is currently active.
+
+  WiFiServer *server_{nullptr};
+#ifdef USE_NEW_OTA
+  WiFiClient client_{};
+#else
+  bool ota_triggered_{false};
+#endif
+
   bool has_safe_mode_{false}; ///< stores whether safe mode can be enabled.
   uint32_t safe_mode_start_time_; ///<stores when safe mode was enabled.
   uint32_t safe_mode_enable_time_{60000}; ///< The time safe mode should be on for.


### PR DESCRIPTION
## Description:

`ArduinoOTA` doesn't work too well, also it does some pretty weird stuff with UDP+TCP.

The new OTA process can be enabled with `-DUSE_NEW_OTA` build flag and esphomeyaml will enable this by default.

It's now entirely based on TCP (with the ESP being the server) and a protocol that supports versioning so that it's future-proof.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#177

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
