### PR TITLE
ESP8266 Pulse Counter Improve Timing

### DIFF
--- a/src/esphomelib/sensor/pulse_counter.cpp
+++ b/src/esphomelib/sensor/pulse_counter.cpp
@@ -68,7 +68,15 @@ void ICACHE_RAM_ATTR HOT PulseCounterBase::gpio_intr() {
 bool PulseCounterBase::pulse_counter_setup_() {
   this->pin_->setup();
   auto intr = std::bind(&PulseCounterSensorComponent::gpio_intr, this);
-  attachInterrupt(this->pin_->get_pin(), intr, CHANGE);
+  int intr_mode = CHANGE;
+  if (this->rising_edge_mode_ == PULSE_COUNTER_DISABLE) {
+    // only falling
+    intr_mode = this->pin_->is_inverted() ? RISING : FALLING;
+  } else if (this->falling_edge_mode_ == PULSE_COUNTER_DISABLE) {
+    // only rising
+    intr_mode = this->pin_->is_inverted() ? FALLING : RISING;
+  }
+  attachInterrupt(this->pin_->get_pin(), intr, intr_mode);
   return true;
 }
 pulse_counter_t PulseCounterBase::read_raw_value_() {

--- a/src/esphomelib/sensor/pulse_counter.cpp
+++ b/src/esphomelib/sensor/pulse_counter.cpp
@@ -47,14 +47,16 @@ void PulseCounterSensorComponent::set_edge_mode(PulseCounterCountMode rising_edg
 const char *EDGE_MODE_TO_STRING[] = {"DISABLE", "INCREMENT", "DECREMENT"};
 
 #ifdef ARDUINO_ARCH_ESP8266
-void ICACHE_RAM_ATTR PulseCounterBase::gpio_intr() {
+void ICACHE_RAM_ATTR HOT PulseCounterBase::gpio_intr() {
   const uint32_t now = micros();
-  if (now - this->last_pulse_ < this->filter_us_) {
+  if (now - this->last_pulse_ < this->filter_us_)
     return;
-  }
+  this->last_pulse_ = now;
+
   PulseCounterCountMode mode = this->pin_->digital_read() ? this->rising_edge_mode_ : this->falling_edge_mode_;
   switch (mode) {
-    case PULSE_COUNTER_DISABLE: break;
+    case PULSE_COUNTER_DISABLE:
+      break;
     case PULSE_COUNTER_INCREMENT:
       this->counter_++;
       break;
@@ -62,7 +64,6 @@ void ICACHE_RAM_ATTR PulseCounterBase::gpio_intr() {
       this->counter_--;
       break;
   }
-  this->last_pulse_ = now;
 }
 bool PulseCounterBase::pulse_counter_setup_() {
   this->pin_->setup();


### PR DESCRIPTION
## Description:

Don't know why there would be 4 pulses, will need some more testing.

In the meantime, maybe this will help improve things: Speed up by marking method as `HOT`, moving `last_pulse` check up (is the interrupt firing twice?), and have a higher-level shortcircuit using the interrupt mode.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
