### PR TITLE
Add power on value setting to switch

### DIFF
--- a/src/esphomelib/output/gpio_binary_output_component.cpp
+++ b/src/esphomelib/output/gpio_binary_output_component.cpp
@@ -24,7 +24,7 @@ void GPIOBinaryOutputComponent::write_enabled(bool value) {
 void GPIOBinaryOutputComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up GPIO Binary Output...");
   this->pin_->setup();
-  this->pin_->digital_write(false);
+  this->pin_->digital_write(this->power_on_value_);
 }
 
 float GPIOBinaryOutputComponent::get_setup_priority() const {
@@ -32,6 +32,10 @@ float GPIOBinaryOutputComponent::get_setup_priority() const {
 }
 GPIOBinaryOutputComponent::GPIOBinaryOutputComponent(GPIOPin *pin)
   : pin_(pin) { }
+
+void GPIOBinaryOutputComponent::set_power_on_value(bool power_on_value) {
+  this->power_on_value_ = power_on_value;
+}
 
 } // namespace output
 

--- a/src/esphomelib/output/gpio_binary_output_component.h
+++ b/src/esphomelib/output/gpio_binary_output_component.h
@@ -45,8 +45,11 @@ class GPIOBinaryOutputComponent : public BinaryOutput, public Component {
   /// Override the BinaryOutput method for writing values to HW.
   void write_enabled(bool value) override;
 
+  void set_power_on_value(bool power_on_value);
+
  protected:
   GPIOPin *pin_;
+  bool power_on_value_{false};
 };
 
 } // namespace output


### PR DESCRIPTION
## Description:

Using `inverted` is too much of a hack.

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#TODO
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#180

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
