### PR TITLE
Fix ESP32 BLE Controller Init

### DIFF
--- a/src/esphomelib/esp32_ble_beacon.cpp
+++ b/src/esphomelib/esp32_ble_beacon.cpp
@@ -72,24 +72,15 @@ void ESP32BLEBeacon::ble_core_task(void *params) {
   }
 }
 void ESP32BLEBeacon::ble_setup() {
-// Initialize non-volatile storage for the bluetooth controller
+  // Initialize non-volatile storage for the bluetooth controller
   esp_err_t err = nvs_flash_init();
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "nvs_flash_init failed: %d", err);
     return;
   }
 
-  // Initialize the bluetooth controller with the default configuration
-  esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-  err = esp_bt_controller_init(&bt_cfg);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bt_controller_init failed: %d", err);
-    return;
-  }
-
-  err = esp_bt_controller_enable(ESP_BT_MODE_BLE);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bt_controller_enable failed: %d", err);
+  if (!btStart()) {
+    ESP_LOGE(TAG, "btStart failed: %d", esp_bt_controller_get_status());
     return;
   }
 

--- a/src/esphomelib/esp32_ble_tracker.cpp
+++ b/src/esphomelib/esp32_ble_tracker.cpp
@@ -106,16 +106,8 @@ void ESP32BLETracker::ble_setup() {
   }
 
   // Initialize the bluetooth controller with the default configuration
-  esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-  err = esp_bt_controller_init(&bt_cfg);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bt_controller_init failed: %d", err);
-    return;
-  }
-
-  err = esp_bt_controller_enable(ESP_BT_MODE_BLE);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bt_controller_enable failed: %d", err);
+  if (!btStart()) {
+    ESP_LOGE(TAG, "btStart failed: %d", esp_bt_controller_get_status());
     return;
   }
 


### PR DESCRIPTION
## Description:

See https://github.com/OttoWinter/esphomeyaml/issues/127#issuecomment-429569674

After some testing, the `enable` command only works after a bit of delay. Additionally, the `init` command is sometimes not necessary because the BT controller is already set up (I presume through soft resets?)

Thank you very much to @guardmedia for this!

(the `btStarted()` check is not necessary because `btStart()` already checks if it's already started, see https://github.com/espressif/arduino-esp32/blob/1.0.0-rc3/cores/esp32/esp32-hal-bt.c#L35)

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
