### PR TITLE
Fix Web Server Creating Infinite Print Loop

### DIFF
--- a/src/esphomelib/web_server.cpp
+++ b/src/esphomelib/web_server.cpp
@@ -485,8 +485,6 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
   return false;
 }
 void WebServer::handleRequest(AsyncWebServerRequest *request) {
-  ESP_LOGD(TAG, "%s %s", request->methodToString(), request->url().c_str());
-
   if (request->url() == "/") {
     this->handle_index_request(request);
     return;


### PR DESCRIPTION
## Description:

#180 had a bug... This will create an infinite print loop and blows up when accessing the index.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
