### PR TITLE
Fix WiFi not working when GPIO 0 connected

### DIFF
--- a/src/esphomelib/wifi_component.cpp
+++ b/src/esphomelib/wifi_component.cpp
@@ -71,39 +71,41 @@ void WiFiComponent::setup() {
     }
     delay(10);
 
+    if (this->power_save_.has_value()) {
 #ifdef ARDUINO_ARCH_ESP32
-    wifi_ps_type_t power_save;
-    switch (this->power_save_) {
-      case WIFI_POWER_SAVE_LIGHT:
-        power_save = WIFI_PS_MIN_MODEM;
-        break;
-      case WIFI_POWER_SAVE_HIGH:
-        power_save = WIFI_PS_MAX_MODEM;
-        break;
-      case WIFI_POWER_SAVE_NONE:
-      default:
-        power_save = WIFI_PS_NONE;
-        break;
-    }
-    esp_wifi_set_ps(power_save);
+      wifi_ps_type_t power_save;
+      switch (*this->power_save_) {
+        case WIFI_POWER_SAVE_LIGHT:
+          power_save = WIFI_PS_MIN_MODEM;
+          break;
+        case WIFI_POWER_SAVE_HIGH:
+          power_save = WIFI_PS_MAX_MODEM;
+          break;
+        case WIFI_POWER_SAVE_NONE:
+        default:
+          power_save = WIFI_PS_NONE;
+          break;
+      }
+      esp_wifi_set_ps(power_save);
 #endif
 
 #ifdef ARDUINO_ARCH_ESP8266
-    sleep_type_t power_save;
-    switch (this->power_save_) {
-      case WIFI_POWER_SAVE_LIGHT:
-        power_save = LIGHT_SLEEP_T;
-        break;
-      case WIFI_POWER_SAVE_HIGH:
-        power_save = MODEM_SLEEP_T;
-        break;
-      case WIFI_POWER_SAVE_NONE:
-      default:
-        power_save = NONE_SLEEP_T;
-        break;
-    }
-    wifi_set_sleep_type(power_save);
+      sleep_type_t power_save;
+      switch (*this->power_save_) {
+        case WIFI_POWER_SAVE_LIGHT:
+          power_save = LIGHT_SLEEP_T;
+          break;
+        case WIFI_POWER_SAVE_HIGH:
+          power_save = MODEM_SLEEP_T;
+          break;
+        case WIFI_POWER_SAVE_NONE:
+        default:
+          power_save = NONE_SLEEP_T;
+          break;
+      }
+      wifi_set_sleep_type(power_save);
 #endif
+    }
 
     this->start_connecting();
   } else if (this->has_ap()) {

--- a/src/esphomelib/wifi_component.h
+++ b/src/esphomelib/wifi_component.h
@@ -180,7 +180,7 @@ class WiFiComponent : public Component {
   uint8_t num_retried_{0};
   uint32_t last_connected_{0};
   uint32_t reboot_timeout_{60000};
-  WiFiPowerSaveMode power_save_{WIFI_POWER_SAVE_NONE};
+  optional<WiFiPowerSaveMode> power_save_{};
 };
 
 extern WiFiComponent *global_wifi_component;


### PR DESCRIPTION
## Description:

Apparently, the WiFi controller doesn't like `NONE` power save mode when `GPIO0` is not in open-drain mode.

This PR reverts back to the old behavior of not changing the power save mode. But if users want to, they can still change it manually.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#TODO

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
