### PR TITLE
MCP23017 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,4 +36,5 @@ test-advanced:
         -e custombmp180 \
         -e i2c-sensors \
         -e pcf8574 \
+        -e mcp23017 \
         -e fastled

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ env:
     - BUILD_TARGET=custombmp180
     - BUILD_TARGET=i2c-sensors
     - BUILD_TARGET=pcf8574
+    - BUILD_TARGET=mcp23017
     - BUILD_TARGET=fastled
 
 script:

--- a/examples/mcp23017/mcp23017.cpp
+++ b/examples/mcp23017/mcp23017.cpp
@@ -1,0 +1,33 @@
+//
+//  Created by Lazar Obradovic on 10.10.18.
+//  Copyright © 2018 Lazar Obradovic. All rights reserved.
+//
+
+#include <esphomelib.h>
+
+using namespace esphomelib;
+
+void setup() {
+  App.set_name("mcp23017");
+  App.init_log();
+
+  App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+  App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+  App.init_ota()->start_safe_mode();
+
+  App.init_i2c(SDA, SCL, true);
+
+  auto *mcp23017 = App.make_mcp23017_component(0x20);
+  App.make_gpio_binary_sensor("MCP pin A0 sensor", mcp23017->make_input_pin(0, MCP23017_INPUT_PULLUP));
+  App.make_gpio_binary_sensor("MCP pin A1 sensor", mcp23017->make_input_pin(1, MCP23017_INPUT));
+
+  App.make_gpio_switch("MCP pin B0 switch", mcp23017->make_output_pin(8));
+  auto *out = App.make_gpio_output(mcp23017->make_output_pin(8));
+  App.make_binary_light("MCP pin B0 light", out);
+
+  App.setup();
+}
+
+void loop() {
+  App.loop();
+}

--- a/examples/mcp23017/mcp23017.ino
+++ b/examples/mcp23017/mcp23017.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/platformio.ini
+++ b/platformio.ini
@@ -89,7 +89,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/pcf8574/pcf8574.cpp>
 
 [env:mcp23017]
-platform = espressif32
+platform = espressif8266
 board = d1_mini
 framework = arduino
 lib_deps = ${common.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -88,7 +88,7 @@ lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/pcf8574/pcf8574.cpp>
 
-[env:pcf8574]
+[env:mcp23017]
 platform = espressif32
 board = d1_mini
 framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -88,6 +88,14 @@ lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/pcf8574/pcf8574.cpp>
 
+[env:pcf8574]
+platform = espressif32
+board = d1_mini
+framework = arduino
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+src_filter = ${common.src_filter} +<examples/mcp23017/mcp23017.cpp>
+
 [env:fastled]
 platform = espressif32
 board = nodemcu-32s

--- a/src/esphomelib/application.cpp
+++ b/src/esphomelib/application.cpp
@@ -597,6 +597,12 @@ PCF8574Component *Application::make_pcf8574_component(uint8_t address, bool pcf8
 }
 #endif
 
+#ifdef USE_MCP23017
+MCP23017Component *Application::make_mcp23017_component(uint8_t address) {
+  return this->register_component(new MCP23017Component(this->i2c_, address));
+}
+#endif
+
 #ifdef USE_MPU6050
 sensor::MPU6050Component *Application::make_mpu6050_sensor(uint8_t address, uint32_t update_interval) {
   return this->register_component(new MPU6050Component(this->i2c_, address, update_interval));

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -41,6 +41,7 @@
 #include "esphomelib/fan/mqtt_fan_component.h"
 #include "esphomelib/i2c_component.h"
 #include "esphomelib/io/pcf8574_component.h"
+#include "esphomelib/io/mcp23017_component.h"
 #include "esphomelib/light/fast_led_light_output.h"
 #include "esphomelib/light/fast_led_light_effect.h"
 #include "esphomelib/light/light_effect.h"
@@ -1212,6 +1213,21 @@ class Application {
    */
   io::PCF8574Component *make_pcf8574_component(uint8_t address = 0x21, bool pcf8575 = false);
 #endif
+
+#ifdef USE_MCP23017
+/** Create a MCP23017 port expander component.
+ *
+ * This component will allow you to emulate GPIOInputPin and GPIOOutputPin instances that
+ * are used within esphomelib. You can therefore simply pass the result of calling
+ * `make_pin` on the component to any method accepting GPIOInputPin or GPIOOutputPin.
+ *
+ * @param address The i2c address to use for this port expander. Defaults to 0x20.
+ * @return The MCP23017Component instance to get individual pins.
+ */
+io::MCP23017Component *make_mcp23017_component(uint8_t address = 0x21);
+
+#endif
+
 
   /// Register the component in this Application instance.
   template<class C>

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -1215,16 +1215,16 @@ class Application {
 #endif
 
 #ifdef USE_MCP23017
-/** Create a MCP23017 port expander component.
- *
- * This component will allow you to emulate GPIOInputPin and GPIOOutputPin instances that
- * are used within esphomelib. You can therefore simply pass the result of calling
- * `make_pin` on the component to any method accepting GPIOInputPin or GPIOOutputPin.
- *
- * @param address The i2c address to use for this port expander. Defaults to 0x20.
- * @return The MCP23017Component instance to get individual pins.
- */
-io::MCP23017Component *make_mcp23017_component(uint8_t address = 0x21);
+  /** Create a MCP23017 port expander component.
+   *
+   * This component will allow you to emulate GPIOInputPin and GPIOOutputPin instances that
+   * are used within esphomelib. You can therefore simply pass the result of calling
+   * `make_pin` on the component to any method accepting GPIOInputPin or GPIOOutputPin.
+   *
+   * @param address The i2c address to use for this port expander. Defaults to 0x20.
+   * @return The MCP23017Component instance to get individual pins.
+   */
+  io::MCP23017Component *make_mcp23017_component(uint8_t address = 0x21);
 
 #endif
 

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -1224,7 +1224,7 @@ class Application {
    * @param address The i2c address to use for this port expander. Defaults to 0x20.
    * @return The MCP23017Component instance to get individual pins.
    */
-  io::MCP23017Component *make_mcp23017_component(uint8_t address = 0x21);
+  io::MCP23017Component *make_mcp23017_component(uint8_t address = 0x20);
 
 #endif
 

--- a/src/esphomelib/defines.h
+++ b/src/esphomelib/defines.h
@@ -62,6 +62,7 @@
   #define USE_WEB_SERVER
   #define USE_DEEP_SLEEP
   #define USE_PCF8574
+  #define USE_MCP23017
   #define USE_IO
   #define USE_MPU6050
   #define USE_TSL2561
@@ -465,6 +466,14 @@
   #endif
 #endif
 #ifdef USE_PCF8574
+  #ifndef USE_I2C
+    #define USE_I2C
+  #endif
+  #ifndef USE_IO
+    #define USE_IO
+  #endif
+#endif
+#ifdef USE_MCP23017
   #ifndef USE_I2C
     #define USE_I2C
   #endif

--- a/src/esphomelib/io/mcp23017_component.cpp
+++ b/src/esphomelib/io/mcp23017_component.cpp
@@ -1,0 +1,218 @@
+//
+//  mcp23017_component.cpp
+//  esphomelib
+//
+//  Created by Lazar Obradovic on 09.10.18.
+//  Copyright © 2018 Lazar Obradovic. All rights reserved.
+//
+// Based on:
+//   - https://github.com/adafruit/Adafruit-MCP23017-Arduino-Library/
+//   - http://ww1.microchip.com/downloads/en/devicedoc/20001952c.pdf
+
+#include "esphomelib/defines.h"
+
+#ifdef USE_MCP23017
+
+#include "esphomelib/io/mcp23017_component.h"
+#include "esphomelib/log.h"
+
+ESPHOMELIB_NAMESPACE_BEGIN
+
+namespace io {
+
+static const char *TAG = "io.mcp23017";
+
+MCP23017Component::MCP23017Component(I2CComponent *parent, uint8_t address)
+    : Component(), I2CDevice(parent, address) {}
+
+void MCP23017Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up MCP23017...");
+  ESP_LOGCONFIG(TAG, "    Address: 0x%02X", this->address_);
+
+  uint8_t iocon;
+  if (!this->read_reg_(MCP23017_IOCONA, &iocon)) {
+    ESP_LOGE(TAG, "MCP23017 not available under 0x%02X", this->address_);
+    this->mark_failed();
+    return;
+  }
+
+  // set defaults, all pins input
+ this->write_reg_ (MCP23017_IODIRA, 0xFF);
+ this->write_reg_ (MCP23017_IODIRB, 0xFF);
+}
+
+bool MCP23017Component::digital_read_(uint8_t pin) {
+  uint8_t bit = bit_for_pin_(pin);
+  uint8_t reg_addr = reg_for_pin_(pin, MCP23017_GPIOA, MCP23017_GPIOB);
+  uint8_t value;
+  this->read_reg_(reg_addr, &value);
+
+  return (value >> bit) & 0x1;
+}
+
+void MCP23017Component::digital_write_(uint8_t pin, bool value) {
+  uint8_t gpio;
+  uint8_t bit = this->bit_for_pin_(pin);
+
+  uint8_t reg_addr = this->reg_for_pin_(pin, MCP23017_OLATA, MCP23017_OLATB);
+  this->read_reg_(reg_addr, &gpio);
+
+  bitWrite(gpio, bit, value);
+
+  // write the new GPIO
+  reg_addr = this->reg_for_pin_(pin, MCP23017_GPIOA, MCP23017_GPIOB);
+  this->write_reg_(reg_addr, gpio);
+}
+
+
+void MCP23017Component::pin_mode_(uint8_t pin, uint8_t mode) {
+  switch (mode) {
+    case MCP23017_INPUT:
+      this->update_reg_(pin, 1, MCP23017_IODIRA, MCP23017_IODIRB);
+      break;
+    case MCP23017_INPUT_PULLUP:
+      this->update_reg_(pin, 1, MCP23017_IODIRA, MCP23017_IODIRB);
+      this->update_reg_(pin, 1, MCP23017_GPPUA, MCP23017_GPPUB);
+      break;
+    case MCP23017_OUTPUT:
+      this->update_reg_(pin, 0, MCP23017_IODIRA, MCP23017_IODIRB);
+      break;
+    default:
+      assert(false);
+  }
+}
+
+uint8_t MCP23017Component::bit_for_pin_(uint8_t pin) {
+  return pin%8;
+}
+
+uint8_t MCP23017Component::reg_for_pin_ (uint8_t pin, uint8_t regA, uint8_t regB) {
+  return (pin < 8) ? regA : regB;
+}
+
+bool MCP23017Component::read_reg_ (uint8_t reg, uint8_t *value) {
+  if (this->is_failed())
+    return false;
+
+  this->parent_->begin_transmission_(this->address_);
+  this->parent_->write_(this->address_, &reg, 1);
+
+  if (!this->parent_->receive_(this->address_, value, 1)) {
+    this->status_set_warning();
+    return false;
+  }
+
+  if (!this->parent_->end_transmission_(this->address_)) {
+    this->status_set_warning();
+    return false;
+  }
+
+  this->status_clear_warning();
+  return true;
+}
+
+bool MCP23017Component::write_reg_ (uint8_t reg, uint8_t value){
+  if (this->is_failed())
+    return false;
+
+  this->parent_->begin_transmission_(this->address_);
+  this->parent_->write_(this->address_, &reg, 1);
+  this->parent_->write_(this->address_, &value, 1);
+
+  if (!this->parent_->end_transmission_(this->address_)) {
+    this->status_set_warning();
+    return false;
+  }
+  this->status_clear_warning();
+  return true;
+
+}
+
+bool MCP23017Component::update_reg_ (uint8_t pin, uint8_t pin_value, uint8_t regA, uint8_t regB){
+  uint8_t reg_addr = this->reg_for_pin_ (pin, regA, regB);
+  uint8_t bit = this->bit_for_pin_ (pin);
+
+  uint8_t reg_value;
+  if (!this->read_reg_(reg_addr, &reg_value)) {
+    this->status_set_warning();
+    return false;
+  }
+  // set the value for the particular bit
+  bitWrite (reg_value, bit, pin_value);
+
+  if(!this->write_reg_ (reg_addr, reg_value)) {
+    this->status_set_warning();
+    return false;
+  }
+  this->status_clear_warning();
+  return true;
+
+}
+
+
+MCP23017GPIOInputPin MCP23017Component::make_input_pin(uint8_t pin, uint8_t mode, bool inverted) {
+  assert(mode == MCP23017_INPUT || mode == MCP23017_INPUT_PULLUP);
+  assert(pin < 16);
+
+  return {this, pin, mode, inverted};
+}
+MCP23017GPIOOutputPin MCP23017Component::make_output_pin(uint8_t pin, bool inverted) {
+  assert(pin < 16);
+  return {this, pin, MCP23017_OUTPUT, inverted};
+}
+
+float MCP23017Component::get_setup_priority() const {
+  return setup_priority::HARDWARE;
+}
+
+
+
+
+
+
+void MCP23017GPIOInputPin::setup() {
+  this->pin_mode(this->mode_);
+}
+bool MCP23017GPIOInputPin::digital_read() {
+  return this->parent_->digital_read_(this->pin_) != this->inverted_;
+}
+void MCP23017GPIOInputPin::digital_write(bool value) {
+  this->parent_->digital_write_(this->pin_, value != this->inverted_);
+}
+MCP23017GPIOInputPin::MCP23017GPIOInputPin(MCP23017Component *parent, uint8_t pin, uint8_t mode, bool inverted)
+    : GPIOInputPin(pin, mode, inverted), parent_(parent) {}
+GPIOPin *MCP23017GPIOInputPin::copy() const {
+  return new MCP23017GPIOInputPin(*this);
+}
+void MCP23017GPIOInputPin::pin_mode(uint8_t mode) {
+  this->parent_->pin_mode_(this->pin_, mode);
+}
+
+
+
+
+
+
+void MCP23017GPIOOutputPin::setup() {
+  this->pin_mode(this->mode_);
+}
+bool MCP23017GPIOOutputPin::digital_read() {
+  return this->parent_->digital_read_(this->pin_) != this->inverted_;
+}
+void MCP23017GPIOOutputPin::digital_write(bool value) {
+  this->parent_->digital_write_(this->pin_, value != this->inverted_);
+}
+MCP23017GPIOOutputPin::MCP23017GPIOOutputPin(MCP23017Component *parent, uint8_t pin, uint8_t mode, bool inverted)
+    : GPIOOutputPin(pin, mode, inverted), parent_(parent) {}
+GPIOPin *MCP23017GPIOOutputPin::copy() const {
+  return new MCP23017GPIOOutputPin(*this);
+}
+void MCP23017GPIOOutputPin::pin_mode(uint8_t mode) {
+  this->parent_->pin_mode_(this->pin_, mode);
+}
+
+} // namespace io
+
+ESPHOMELIB_NAMESPACE_END
+
+#endif //USE_MCP23017

--- a/src/esphomelib/io/mcp23017_component.h
+++ b/src/esphomelib/io/mcp23017_component.h
@@ -1,0 +1,158 @@
+//
+//  mcp23017_component.h
+//  esphomelib
+//
+//  Created by Lazar Obradovic on 09.10.18.
+//  Copyright © 2018 Lazar Obradovic. All rights reserved.
+//
+
+#ifndef ESPHOMELIB_MCP_23017_COMPONENT_H
+#define ESPHOMELIB_MCP_23017_COMPONENT_H
+
+#include "esphomelib/defines.h"
+
+#ifdef USE_MCP23017
+
+#include "esphomelib/component.h"
+#include "esphomelib/esphal.h"
+#include "esphomelib/i2c_component.h"
+
+ESPHOMELIB_NAMESPACE_BEGIN
+
+/// Modes for MCP23017 pins
+enum MCP23017GPIOMode {
+  MCP23017_INPUT = INPUT,   // 0x00
+  MCP23017_INPUT_PULLUP = INPUT_PULLUP, // 0x02
+  MCP23017_OUTPUT = OUTPUT, // 0x01
+};
+
+enum MCP23017GPIORegisters {
+    // A side
+    MCP23017_IODIRA = 0x00,
+    MCP23017_IPOLA = 0x02,
+    MCP23017_GPINTENA = 0x04,
+    MCP23017_DEFVALA = 0x06,
+    MCP23017_INTCONA = 0x08,
+    MCP23017_IOCONA = 0x0A,
+    MCP23017_GPPUA = 0x0C,
+    MCP23017_INTFA = 0x0E,
+    MCP23017_INTCAPA = 0x10,
+    MCP23017_GPIOA = 0x12,
+    MCP23017_OLATA = 0x14,
+    // B side
+    MCP23017_IODIRB = 0x01,
+    MCP23017_IPOLB = 0x03,
+    MCP23017_GPINTENB = 0x05,
+    MCP23017_DEFVALB = 0x07,
+    MCP23017_INTCONB = 0x09,
+    MCP23017_IOCONB = 0x0B,
+    MCP23017_GPPUB = 0x0D,
+    MCP23017_INTFB = 0x0F,
+    MCP23017_INTCAPB = 0x11,
+    MCP23017_GPIOB = 0x13,
+    MCP23017_OLATB = 0x15,
+
+};
+
+namespace io {
+
+class MCP23017GPIOInputPin;
+class MCP23017GPIOOutputPin;
+
+class MCP23017Component : public Component, public I2CDevice {
+ public:
+  MCP23017Component(I2CComponent *parent, uint8_t address);
+
+  /** Make a GPIOPin that can be used in other components.
+   *
+   * Note that in some cases this component might not work with incompatible other integrations
+   * because for performance reasons the values are only sent once every loop cycle in a batch.
+   * For example, OneWire sensors are not supported.
+   *
+   * @param pin The pin number to use. 0-15 for MCP23017.
+   * @param mode The pin mode to use. Only supported ones are MCP23017_INPUT, MCP23017_INPUT_PULLUP.
+   * @param inverted If the pin should invert all incoming and outgoing values.
+   * @return An MCP23017PIOPin instance.
+   */
+  MCP23017GPIOInputPin make_input_pin(uint8_t pin, uint8_t mode = MCP23017_INPUT, bool inverted = false);
+
+  /** Make a GPIOPin that can be used in other components.
+   *
+   * Note that in some cases this component might not work with incompatible other integrations
+   * because for performance reasons the values are only sent once every loop cycle in a batch.
+   * For example, OneWire sensors are not supported.
+   *
+   * @param pin The pin number to use. 0-15 for MCP23017.
+   * @param inverted If the pin should invert all incoming and outgoing values.
+   * @return An MCP23017GPIOPin instance.
+   */
+  MCP23017GPIOOutputPin make_output_pin(uint8_t pin, bool inverted = false);
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  /// Check i2c availability and setup masks
+  void setup() override;
+  /// Helper function to read the value of a pin.
+  bool digital_read_(uint8_t pin);
+  /// Helper function to write the value of a pin.
+  void digital_write_(uint8_t pin, bool value);
+  /// Helper function to set the pin mode of a pin.
+  void pin_mode_(uint8_t pin, uint8_t mode);
+
+  float get_setup_priority() const override;
+
+ protected:
+  // figure out which bit is it, for a given pin number.
+  // problem comes from A/B side mapping, and reverse order of high-low byte value
+  uint8_t bit_for_pin_(uint8_t pin);
+  // figure out which register of the given 2 is it.
+  uint8_t reg_for_pin_ (uint8_t pin, uint8_t regA, uint8_t regB);
+
+  // read a given register
+  bool read_reg_ (uint8_t reg, uint8_t *value);
+  // write a value to a given register
+  bool write_reg_ (uint8_t reg, uint8_t value);
+  // update registers with given pin value.
+  bool update_reg_ (uint8_t pin, uint8_t pin_value, uint8_t regA, uint8_t regB);
+
+};
+
+/// Helper class to expose a MCP23017 pin as an internal input GPIO pin.
+class MCP23017GPIOInputPin : public GPIOInputPin {
+ public:
+  MCP23017GPIOInputPin(MCP23017Component *parent, uint8_t pin, uint8_t mode, bool inverted = false);
+
+  GPIOPin *copy() const override;
+
+  void setup() override;
+  void pin_mode(uint8_t mode) override;
+  bool digital_read() override;
+  void digital_write(bool value) override;
+
+ protected:
+  MCP23017Component *parent_;
+};
+
+/// Helper class to expose a MCP23017 pin as an internal output GPIO pin.
+class MCP23017GPIOOutputPin : public GPIOOutputPin {
+ public:
+  MCP23017GPIOOutputPin(MCP23017Component *parent, uint8_t pin, uint8_t mode, bool inverted = false);
+
+  GPIOPin *copy() const override;
+
+  void setup() override;
+  void pin_mode(uint8_t mode) override;
+  bool digital_read() override;
+  void digital_write(bool value) override;
+
+ protected:
+  MCP23017Component *parent_;
+};
+
+} // namespace io
+
+ESPHOMELIB_NAMESPACE_END
+
+#endif //USE_MCP23017
+
+#endif //ESPHOMELIB_MCP_23017_COMPONENT_H

--- a/src/esphomelib/io/mcp23017_component.h
+++ b/src/esphomelib/io/mcp23017_component.h
@@ -102,11 +102,6 @@ class MCP23017Component : public Component, public I2CDevice {
   float get_setup_priority() const override;
 
  protected:
-  // figure out which bit is it, for a given pin number.
-  // problem comes from A/B side mapping, and reverse order of high-low byte value
-  uint8_t bit_for_pin_(uint8_t pin);
-  // figure out which register of the given 2 is it.
-  uint8_t reg_for_pin_ (uint8_t pin, uint8_t regA, uint8_t regB);
 
   // read a given register
   bool read_reg_ (uint8_t reg, uint8_t *value);


### PR DESCRIPTION
## Description:

This adds support for MCP23017 multiplexers. 

**Related issue:** implements #162, #106

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#53

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#185

## Example entry for YAML configuration (if applicable):
```yaml
    mcp23017:
      - id: 'mcp23017_hub'
        address: 0x20

    # Individual outputs
    switch:
      - platform: gpio
        name: "MCP23017 Pin #0"
        pin:
          mcp23017: mcp23017_hub
          # Use pin number 0
          number: 0
          # One of INPUT, INPUT_PULLUP or OUTPUT
          mode: OUTPUT
          inverted: False
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
