### PR TITLE
Add FastLED color correction option

### DIFF
--- a/src/esphomelib/light/fast_led_light_output.cpp
+++ b/src/esphomelib/light/fast_led_light_output.cpp
@@ -32,6 +32,7 @@ void FastLEDLightOutputComponent::setup() {
   assert(this->controller_ != nullptr && "You need to add LEDs to this controller!");
   this->controller_->init();
   this->controller_->setLeds(this->leds_, this->num_leds_);
+  this->controller_->setCorrection(this->correction_);
   if (!this->max_refresh_rate_.has_value()) {
     this->set_max_refresh_rate(this->controller_->getMaxRefreshRate());
   }
@@ -121,6 +122,9 @@ CRGB *FastLEDLightOutputComponent::begin() { return &this->leds()[0]; }
 CRGB *FastLEDLightOutputComponent::end() { return &this->leds()[this->size()]; }
 uint8_t *FastLEDLightOutputComponent::effect_data() const {
   return this->effect_data_;
+}
+void FastLEDLightOutputComponent::set_correction(float red, float green, float blue) {
+  this->correction_ = CRGB(red * 255, green * 255, blue * 255);
 }
 
 #endif

--- a/src/esphomelib/light/fast_led_light_output.h
+++ b/src/esphomelib/light/fast_led_light_output.h
@@ -59,6 +59,8 @@ class FastLEDLightOutputComponent : public LightOutput, public Component {
 
   void set_power_supply(PowerSupplyComponent *power_supply);
 
+  void set_correction(float red, float green, float blue);
+
   /// Add some LEDS, can only be called once.
   CLEDController &add_leds(CLEDController *controller, int num_leds);
 
@@ -338,6 +340,7 @@ class FastLEDLightOutputComponent : public LightOutput, public Component {
  protected:
   CLEDController *controller_{nullptr};
   CRGB *leds_{nullptr};
+  CRGB correction_{UncorrectedColor};
   uint8_t *effect_data_{nullptr};
   int num_leds_{0};
   uint32_t last_refresh_{0};


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#64
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#200

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
