### PR TITLE
Add send_first_at option to sliding window sensor filter

### DIFF
--- a/src/esphomelib/sensor/filter.cpp
+++ b/src/esphomelib/sensor/filter.cpp
@@ -12,8 +12,8 @@ ESPHOMELIB_NAMESPACE_BEGIN
 
 namespace sensor {
 
-SlidingWindowMovingAverageFilter::SlidingWindowMovingAverageFilter(size_t window_size, size_t send_every)
-    : send_every_(send_every), send_at_(send_every - 1),
+SlidingWindowMovingAverageFilter::SlidingWindowMovingAverageFilter(size_t window_size, size_t send_every, size_t send_first_at)
+    : send_every_(send_every), send_at_(send_every - send_first_at),
       value_average_(SlidingWindowMovingAverage(window_size)) {
 
 }

--- a/src/esphomelib/sensor/filter.h
+++ b/src/esphomelib/sensor/filter.h
@@ -64,8 +64,11 @@ class SlidingWindowMovingAverageFilter : public Filter {
    *
    * @param window_size The number of values that should be averaged.
    * @param send_every After how many sensor values should a new one be pushed out.
+   * @param send_first_at After how many values to forward the very first value. Defaults to the first value
+   *   on startup being published on the first *raw* value, so with no filter applied. Must be less than or equal to
+   *   send_every.
    */
-  explicit SlidingWindowMovingAverageFilter(size_t window_size, size_t send_every);
+  explicit SlidingWindowMovingAverageFilter(size_t window_size, size_t send_every, uint32_t send_first_at = 1);
 
   optional<float> new_value(float value) override;
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#69
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#207

## Example entry for YAML configuration (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
