### PR TITLE
OTA Read back server acknowledgement

### DIFF
--- a/src/esphomelib/ota_component.cpp
+++ b/src/esphomelib/ota_component.cpp
@@ -343,6 +343,12 @@ void OTAComponent::handle_() {
 
   // Acknowledge Update end OK - 1 byte
   this->client_.write(OTA_RESPONSE_UPDATE_END_OK);
+
+  // Read ACK
+  if (!this->wait_receive_(buf, 1) || buf[0] != OTA_RESPONSE_OK) {
+    ESP_LOGW(TAG, "Reading back acknowledgement failed!");
+    // do not go to error, this is not fatal
+  }
   this->client_.flush();
   this->client_.stop();
   delay(10);


### PR DESCRIPTION
## Description:

Should prevent cases where the WiFi stack shuts down before the acknowledgement is received by the OTA sender.

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** https://github.com/OttoWinter/esphomeyaml/commit/e3094d9689bc86db2b93c1da8071e2bfef5ad516

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).
