### PR TITLE
MY9231/MY9291 LED driver support

### DIFF
--- a/examples/sonoff-b1/sonoff-b1.cpp
+++ b/examples/sonoff-b1/sonoff-b1.cpp
@@ -1,0 +1,38 @@
+#include <esphomelib.h>
+
+using namespace esphomelib;
+
+static const char *TAG = "main";
+
+static const float cold_white_mireds = 1000000 / 6500;  // 6500 K
+static const float warm_white_mireds = 1000000 / 2800;  // 2800 K
+
+void setup() {
+  App.set_name("sonoff_b1");
+  App.init_log();
+
+  App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+  App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+  auto *ota = App.init_ota();
+  // Set a plaintext password, alternatively use an MD5 hash for maximum security (set_auth_password_hash)
+  ota->set_auth_plaintext_password("VERY_SECURE");
+  ota->start_safe_mode();
+
+  auto *my9231 = App.make_my9231_component(GPIOOutputPin(12),
+                                           GPIOOutputPin(14));
+  my9231->set_num_channels(6);  // two MY9231 chips with each 3 channels
+  my9231->set_num_chips(2);
+  auto *blue = my9231->create_channel(0);
+  auto *red = my9231->create_channel(1);
+  auto *green = my9231->create_channel(2);
+  auto *warm_white = my9231->create_channel(4);
+  auto *cold_white = my9231->create_channel(5);
+  App.make_rgbww_light("Sonoff B1", cold_white_mireds, warm_white_mireds,
+                       red, green, blue, cold_white, warm_white);
+
+  App.setup();
+}
+
+void loop() {
+  App.loop();
+}

--- a/examples/sonoff-b1/sonoff-b1.ino
+++ b/examples/sonoff-b1/sonoff-b1.ino
@@ -1,0 +1,2 @@
+// This file intentionally left blank
+// See other tab for the code

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,3 +95,12 @@ framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/fastled/fastled.cpp>
+
+[env:sonoff-b1]
+platform = espressif8266
+board = esp01_1m
+board_build.flash_mode = dout
+framework = arduino
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+src_filter = ${common.src_filter} +<examples/sonoff-b1/sonoff-b1.cpp>

--- a/src/esphomelib/application.cpp
+++ b/src/esphomelib/application.cpp
@@ -240,6 +240,14 @@ PCA9685OutputComponent *Application::make_pca9685_component(float frequency) {
 }
 #endif
 
+#ifdef USE_MY9231_OUTPUT
+MY9231OutputComponent *Application::make_my9231_component(const GPIOOutputPin &pin_di,
+                                                          const GPIOOutputPin &pin_dcki) {
+  auto *my9231 = new MY9231OutputComponent(pin_di.copy(), pin_dcki.copy());
+  return this->register_component(my9231);
+}
+#endif
+
 #ifdef USE_LIGHT
 Application::MakeLight Application::make_rgb_light(const std::string &friendly_name,
                                                    FloatOutput *red, FloatOutput *green, FloatOutput *blue) {

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -60,6 +60,7 @@
 #include "esphomelib/output/gpio_binary_output_component.h"
 #include "esphomelib/output/ledc_output_component.h"
 #include "esphomelib/output/pca9685_output_component.h"
+#include "esphomelib/output/my9231_output_component.h"
 #include "esphomelib/remote/lg.h"
 #include "esphomelib/remote/nec.h"
 #include "esphomelib/remote/panasonic.h"
@@ -1022,6 +1023,16 @@ class Application {
   output::ESP8266PWMOutput *make_esp8266_pwm_output(GPIOOutputPin pin_);
 #endif
 
+#ifdef USE_MY9231_OUTPUT
+  /** Create a MY9231 component.
+   *
+   * @param pin_di The pin which DI is connected to.
+   * @param pin_dcki The pin which DCKI is connected to.
+   * @return The MY9231 component. Use this for advanced settings.
+   */
+  output::MY9231OutputComponent *make_my9231_component(const GPIOOutputPin &pin_di,
+                                                       const GPIOOutputPin &pin_dcki);
+#endif
 
 
 

--- a/src/esphomelib/defines.h
+++ b/src/esphomelib/defines.h
@@ -118,6 +118,7 @@
   #define USE_STEPPER
   #define USE_A4988
   #define USE_TOTAL_DAILY_ENERGY_SENSOR
+  #define USE_MY9231_OUTPUT
 #endif
 
 #ifdef USE_REMOTE_RECEIVER
@@ -573,6 +574,12 @@
   #endif
   #ifndef USE_TIME
     #define USE_TIME
+  #endif
+#endif
+
+#ifdef USE_MY9231_OUTPUT
+  #ifndef USE_OUTPUT
+    #define USE_OUTPUT
   #endif
 #endif
 

--- a/src/esphomelib/output/my9231_output_component.cpp
+++ b/src/esphomelib/output/my9231_output_component.cpp
@@ -1,0 +1,189 @@
+// Based on:
+//   - https://github.com/xoseperez/my92xx
+
+#include "esphomelib/defines.h"
+
+#ifdef USE_MY9231_OUTPUT
+
+#include "esphomelib/log.h"
+#include "esphomelib/output/my9231_output_component.h"
+
+ESPHOMELIB_NAMESPACE_BEGIN
+
+namespace output {
+
+static const char *TAG = "output.my9231";
+
+// One-shot select (frame cycle repeat mode / frame cycle One-shot mode)
+static const uint8_t MY9231_CMD_ONE_SHOT_DISABLE = 0x0 << 6;
+static const uint8_t MY9231_CMD_ONE_SHOT_ENFORCE = 0x1 << 6;
+// Reaction time of Iout
+static const uint8_t MY9231_CMD_REACTION_FAST = 0x0 << 5;
+static const uint8_t MY9231_CMD_REACTION_SLOW = 0x1 << 5;
+// Grayscale resolution select
+static const uint8_t MY9231_CMD_BIT_WIDTH_16 = 0x0 << 3;
+static const uint8_t MY9231_CMD_BIT_WIDTH_14 = 0x1 << 3;
+static const uint8_t MY9231_CMD_BIT_WIDTH_12 = 0x2 << 3;
+static const uint8_t MY9231_CMD_BIT_WIDTH_8 = 0x3 << 3;
+// Internal oscillator freq. select (divider)
+static const uint8_t MY9231_CMD_FREQUENCY_DIVIDE_1 = 0x0 << 1;
+static const uint8_t MY9231_CMD_FREQUENCY_DIVIDE_4 = 0x1 << 1;
+static const uint8_t MY9231_CMD_FREQUENCY_DIVIDE_16 = 0x2 << 1;
+static const uint8_t MY9231_CMD_FREQUENCY_DIVIDE_64 = 0x3 << 1;
+// Output waveform
+static const uint8_t MY9231_CMD_SCATTER_APDM = 0x0 << 0;
+static const uint8_t MY9231_CMD_SCATTER_PWM = 0x1 << 0;
+
+MY9231OutputComponent::MY9231OutputComponent(GPIOPin *pin_di, GPIOPin *pin_dcki,
+                                             uint16_t num_channels,
+                                             uint8_t num_chips,
+                                             uint8_t bit_depth, bool update)
+    : pin_di_(pin_di),
+      pin_dcki_(pin_dcki),
+      num_channels_(num_channels),
+      num_chips_(num_chips),
+      bit_depth_(bit_depth),
+      update_(update) {}
+
+void MY9231OutputComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up MY9231OutputComponent.");
+  this->pin_di_->setup();
+  this->pin_di_->digital_write(false);
+  ESP_LOGCONFIG(TAG, "    DI Pin: GPIO%d", this->pin_di_->get_pin());
+  this->pin_dcki_->setup();
+  this->pin_dcki_->digital_write(false);
+  ESP_LOGCONFIG(TAG, "    DCKI Pin: GPIO%d", this->pin_dcki_->get_pin());
+  this->pwm_amounts_.resize(this->num_channels_, 0);
+  ESP_LOGCONFIG(TAG, "    Total number of channels: %u", this->num_channels_);
+  ESP_LOGCONFIG(TAG, "    Number of chips: %u", this->num_chips_);
+  uint8_t command = 0;
+  if (this->bit_depth_ <= 8) {
+    this->bit_depth_ = 8;
+    command |= MY9231_CMD_BIT_WIDTH_8;
+  } else if (this->bit_depth_ <= 12) {
+    this->bit_depth_ = 12;
+    command |= MY9231_CMD_BIT_WIDTH_12;
+  } else if (this->bit_depth_ <= 14) {
+    this->bit_depth_ = 14;
+    command |= MY9231_CMD_BIT_WIDTH_14;
+  } else {
+    this->bit_depth_ = 16;
+    command |= MY9231_CMD_BIT_WIDTH_16;
+  }
+  ESP_LOGCONFIG(TAG, "    Bit depth: %u", this->bit_depth_);
+  command |= MY9231_CMD_SCATTER_APDM | MY9231_CMD_FREQUENCY_DIVIDE_1 |
+             MY9231_CMD_REACTION_FAST | MY9231_CMD_ONE_SHOT_DISABLE;
+  ESP_LOGCONFIG(TAG, "    Command: 0x%02X", command);
+
+  this->init_chips(command);
+  ESP_LOGV(TAG, "Chips initialized.");
+  this->loop();
+}
+
+void MY9231OutputComponent::loop() {
+  if (!this->update_) {
+    return;
+  }
+
+  for (auto pwm_amount : this->pwm_amounts_) {
+    this->write_word(pwm_amount, this->bit_depth_);
+  }
+  // Send 8 DI pulses. After 8 falling edges, the duty data are store.
+  this->send_di_pulses(8);
+  this->update_ = false;
+}
+
+MY9231OutputComponent::Channel *MY9231OutputComponent::create_channel(
+    uint8_t channel, PowerSupplyComponent *power_supply, float max_power) {
+  ESP_LOGV(TAG, "Getting channel %d...", channel);
+  auto *c = new Channel(this, channel);
+  c->set_power_supply(power_supply);
+  c->set_max_power(max_power);
+  return c;
+}
+
+float MY9231OutputComponent::get_setup_priority() const {
+  return setup_priority::HARDWARE;
+}
+
+void MY9231OutputComponent::set_channel_value(uint8_t channel, uint16_t value) {
+  ESP_LOGV(TAG, "set channels %u to %u", channel, value);
+  uint8_t index = this->num_channels_ - channel - 1;
+  if (this->pwm_amounts_[index] != value) {
+    this->update_ = true;
+  }
+  this->pwm_amounts_[index] = value;
+}
+
+void MY9231OutputComponent::set_num_channels(uint16_t num_channels) {
+  this->num_channels_ = num_channels;
+}
+
+uint16_t MY9231OutputComponent::get_num_channels() const {
+  return this->num_channels_;
+}
+
+void MY9231OutputComponent::set_num_chips(uint8_t num_chips) {
+  this->num_chips_ = num_chips;
+}
+
+uint8_t MY9231OutputComponent::get_num_chips() const {
+  return this->num_chips_;
+}
+
+void MY9231OutputComponent::set_bit_depth(uint8_t bit_depth) {
+  this->bit_depth_ = bit_depth;
+}
+
+uint8_t MY9231OutputComponent::get_bit_depth() const {
+  return this->bit_depth_;
+}
+
+void MY9231OutputComponent::set_update(bool update) { this->update_ = update; }
+
+uint16_t MY9231OutputComponent::get_max_amount() const {
+  return (uint32_t(1) << this->bit_depth_) - 1;
+}
+
+void MY9231OutputComponent::init_chips(uint8_t command) {
+  // Send 12 DI pulse. After 6 falling edges, the duty data are stored
+  // and after 12 rising edges the command mode is activated.
+  this->send_di_pulses(12);
+  delayMicroseconds(12);
+  for (uint8_t i = 0; i < this->num_chips_; i++) {
+    this->write_word(command, 8);
+  }
+  // Send 16 DI pulse. After 14 falling edges, the command data are
+  // stored and after 16 falling edges the duty mode is activated.
+  this->send_di_pulses(16);
+}
+
+void MY9231OutputComponent::write_word(uint16_t value, uint8_t bits) {
+  for (uint8_t i = bits; i > 0; i--) {
+    this->pin_di_->digital_write(value & (1 << (i - 1)));
+    this->pin_dcki_->digital_write(!this->pin_dcki_->digital_read());
+  }
+}
+
+void MY9231OutputComponent::send_di_pulses(uint8_t count) {
+  delayMicroseconds(12);
+  for (uint8_t i = 0; i < count; i++) {
+    this->pin_di_->digital_write(true);
+    this->pin_di_->digital_write(false);
+  }
+}
+
+MY9231OutputComponent::Channel::Channel(MY9231OutputComponent *parent,
+                                        uint8_t channel)
+    : FloatOutput(), parent_(parent), channel_(channel) {}
+
+void MY9231OutputComponent::Channel::write_state(float state) {
+  auto amount = uint16_t(state * this->parent_->get_max_amount());
+  this->parent_->set_channel_value(this->channel_, amount);
+}
+
+}  // namespace output
+
+ESPHOMELIB_NAMESPACE_END
+
+#endif  // USE_MY9231_OUTPUT

--- a/src/esphomelib/output/my9231_output_component.h
+++ b/src/esphomelib/output/my9231_output_component.h
@@ -1,0 +1,100 @@
+#ifndef ESPHOMELIB_OUTPUT_MY9231_OUTPUT_COMPONENT_H
+#define ESPHOMELIB_OUTPUTP_MY9231_OUTPUT_COMPONENT_H
+
+#include "esphomelib/defines.h"
+
+#ifdef USE_MY9231_OUTPUT
+
+#include "esphomelib/output/float_output.h"
+
+ESPHOMELIB_NAMESPACE_BEGIN
+
+namespace output {
+
+/// MY9231 float output component.
+class MY9231OutputComponent : public Component {
+ public:
+  class Channel;
+  /** Construct the component.
+   *
+   * @param pin_di The pin which DI is connected to.
+   * @param pin_dcki The pin which DCKI is connected to.
+   * @param num_channels Total number of channels of the whole daisy chain.
+   * @param num_chips Number of chips in the daisy chain.
+   * @param bit_depth Bit depth of each channel
+   * @param update Update/reset duty data at boot (driver will keep
+   *               configuration after powercycle)
+   */
+  MY9231OutputComponent(GPIOPin *pin_di, GPIOPin *pin_dcki,
+                        uint16_t num_channels = 6, uint8_t num_chips = 2,
+                        uint8_t bit_depth = 16, bool update = true);
+
+  /** Get a MY9231 output channel.
+   *
+   * @param channel The channel number. (0 is the closest channel)
+   * @param power_supply The power supply that should be set for this channel.
+   *                     Default: nullptr.
+   * @param max_power The maximum power output of this channel. Each value will
+   *                  be multiplied by this.
+   * @return The new channel output component.
+   */
+  Channel *create_channel(uint8_t channel,
+                          PowerSupplyComponent *power_supply = nullptr,
+                          float max_power = 1.0f);
+
+  /// Manually set the total number of channels. Defaults to 6.
+  void set_num_channels(uint16_t num_channels);
+  /// Manually set the number of chips. Defaults to 2.
+  void set_num_chips(uint8_t num_chips);
+  /// Manually set the bit depth. Defaults to 16.
+  void set_bit_depth(uint8_t bit_depth);
+  /// Manually set duty data update on boot. Defaults is true.
+  void set_update(bool update);
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  uint16_t get_num_channels() const;
+  uint8_t get_num_chips() const;
+  uint8_t get_bit_depth() const;
+  uint16_t get_max_amount() const;
+
+  /// Setup the MY9231.
+  void setup() override;
+  /// HARDWARE setup_priority
+  float get_setup_priority() const override;
+  /// Send new values if they were updated.
+  void loop() override;
+
+  class Channel : public FloatOutput {
+   public:
+    Channel(MY9231OutputComponent *parent, uint8_t channel);
+
+    void write_state(float state) override;
+
+   protected:
+    MY9231OutputComponent *parent_;
+    uint8_t channel_;
+  };
+
+ protected:
+  void set_channel_value(uint8_t channel, uint16_t value);
+  void init_chips(uint8_t cmd);
+  void write_word(uint16_t value, uint8_t bits);
+  void send_di_pulses(uint8_t count);
+
+  GPIOPin *pin_di_;
+  GPIOPin *pin_dcki_;
+  uint8_t bit_depth_;
+  uint16_t num_channels_;
+  uint8_t num_chips_;
+  std::vector<uint16_t> pwm_amounts_;
+  bool update_;
+};
+
+}  // namespace output
+
+ESPHOMELIB_NAMESPACE_END
+
+#endif  // USE_MY9231_OUTPUT
+
+#endif  // ESPHOMELIB_OUTPUT_MY9231_OUTPUT_COMPONENT_H


### PR DESCRIPTION
## Description:
Implementation of  MY-SEMI MY9231 family LED driver.
Should support at least the following driver modules:
- MY9291 (4 channels)
- MY9231 (3 channels)
    
They are used in e.g., the following light blub:
- Sonoff B1 (MY9231)
- Ai-Thinker AiLight WiFi light bulb (MY9291)
- Arilux E27 Smart Bulb (MY9231)

Tested with Sonoff B1 r2.
Code is adapted from [MY92XX LED driver library for Arduino AVR and ESP8266](https://github.com/xoseperez/my92xx). Unfortunately, there is no free detailed Datasheet available and the descriptions of the [MY9221](https://raw.githubusercontent.com/SeeedDocument/Grove-LED_Bar/master/res/MY9221_DS_1.0.pdf) seems not be compatible with the MY9231.

**Related issue (if applicable):** fixes

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#80
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#227

## Example entry for YAML configuration (if applicable):
```yaml
my9231:
  data_pin: GPIO12
  clock_pin: GPIO14
  num_channels: 6
  num_chips: 2

output:
  - platform: my9231
    id: output_blue
    channel: 0
  - platform: my9231
    id: output_red
    channel: 1
  - platform: my9231
    id: output_green
    channel: 2
  - platform: my9231
    id: output_warm_white
    channel: 4
  - platform: my9231
    id: output_cold_white
    channel: 5

light:
  - platform: rgbww
    name: "Sonoff B1"
    red: output_red
    green: output_green
    blue: output_blue
    cold_white: output_cold_white
    warm_white: output_warm_white
    cold_white_color_temperature: 6500 K
    warm_white_color_temperature: 2800 K
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
