### PR TITLE
Add support for MAX31855 sensor

### DIFF
--- a/src/esphomelib/application.cpp
+++ b/src/esphomelib/application.cpp
@@ -829,9 +829,9 @@ Application::MakeTemplateSensor Application::make_template_sensor(const std::str
 
 #ifdef USE_MAX31855_SENSOR
 Application::MakeMAX31855Sensor Application::make_max31855_sensor(const std::string &name,
-                                                                SPIComponent *spi_bus,
-                                                                const GPIOOutputPin &cs,
-                                                                uint32_t update_interval) {
+                                                                  SPIComponent *spi_bus,
+                                                                  const GPIOOutputPin &cs,
+                                                                  uint32_t update_interval) {
   auto *sensor = this->register_component(
       new MAX31855Sensor(name, spi_bus, cs.copy(), update_interval)
   );

--- a/src/esphomelib/application.cpp
+++ b/src/esphomelib/application.cpp
@@ -827,6 +827,22 @@ Application::MakeTemplateSensor Application::make_template_sensor(const std::str
 }
 #endif
 
+#ifdef USE_MAX31855_SENSOR
+Application::MakeMAX31855Sensor Application::make_max31855_sensor(const std::string &name,
+                                                                SPIComponent *spi_bus,
+                                                                const GPIOOutputPin &cs,
+                                                                uint32_t update_interval) {
+  auto *sensor = this->register_component(
+      new MAX31855Sensor(name, spi_bus, cs.copy(), update_interval)
+  );
+
+  return MakeMAX31855Sensor{
+      .max31855 = sensor,
+      .mqtt = this->register_sensor(sensor),
+  };
+}
+#endif
+
 #ifdef USE_MAX6675_SENSOR
 Application::MakeMAX6675Sensor Application::make_max6675_sensor(const std::string &name,
                                                                 SPIComponent *spi_bus,

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -96,6 +96,7 @@
 #include "esphomelib/sensor/hx711.h"
 #include "esphomelib/sensor/ina219.h"
 #include "esphomelib/sensor/ina3221.h"
+#include "esphomelib/sensor/max31855_sensor.h"
 #include "esphomelib/sensor/max6675_sensor.h"
 #include "esphomelib/sensor/mhz19_component.h"
 #include "esphomelib/sensor/mpu6050_component.h"
@@ -817,6 +818,16 @@ class Application {
   };
 
   MakeTemplateSensor make_template_sensor(const std::string &name, uint32_t update_interval = 15000);
+#endif
+
+#ifdef USE_MAX31855_SENSOR
+  struct MakeMAX31855Sensor {
+    sensor::MAX31855Sensor *max31855;
+    sensor::MQTTSensorComponent *mqtt;
+  };
+
+  MakeMAX31855Sensor make_max31855_sensor(const std::string &name, SPIComponent *spi_bus, const GPIOOutputPin &cs,
+                                        uint32_t update_interval = 15000);
 #endif
 
 #ifdef USE_MAX6675_SENSOR

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -827,7 +827,7 @@ class Application {
   };
 
   MakeMAX31855Sensor make_max31855_sensor(const std::string &name, SPIComponent *spi_bus, const GPIOOutputPin &cs,
-                                        uint32_t update_interval = 15000);
+                                          uint32_t update_interval = 15000);
 #endif
 
 #ifdef USE_MAX6675_SENSOR

--- a/src/esphomelib/defines.h
+++ b/src/esphomelib/defines.h
@@ -75,6 +75,7 @@
   #endif
   #define USE_FAST_LED_LIGHT
   #define USE_ROTARY_ENCODER_SENSOR
+  #define USE_MAX31855_SENSOR
   #define USE_MAX6675_SENSOR
   #define USE_TEMPLATE_BINARY_SENSOR
   #define USE_TEMPLATE_SWITCH
@@ -344,6 +345,11 @@
   #endif
 #endif
 #ifdef USE_ESP32_HALL_SENSOR
+  #ifndef USE_SENSOR
+    #define USE_SENSOR
+  #endif
+#endif
+#ifdef USE_MAX31855_SENSOR
   #ifndef USE_SENSOR
     #define USE_SENSOR
   #endif

--- a/src/esphomelib/sensor/max31855_sensor.cpp
+++ b/src/esphomelib/sensor/max31855_sensor.cpp
@@ -1,0 +1,114 @@
+// Implementation based on https://github.com/adafruit/MAX31855-library/blob/master/max31855.cpp and https://github.com/adafruit/Adafruit_CircuitPython_MAX31855/blob/master/adafruit_max31855.py
+
+#include "esphomelib/defines.h"
+
+#ifdef USE_MAX31855_SENSOR
+
+#include "esphomelib/sensor/max31855_sensor.h"
+#include "esphomelib/log.h"
+
+ESPHOMELIB_NAMESPACE_BEGIN
+
+namespace sensor {
+
+static const char *TAG = "sensor.max31855";
+
+void MAX31855Sensor::update() {
+  this->enable();
+  delay(1);
+  // conversion initiated by rising edge
+  this->disable();
+
+  // Conversion time typ: 170ms, max: 220ms
+  auto f = std::bind(&MAX31855Sensor::read_data_, this);
+  this->set_timeout("value", 220, f);
+}
+
+void MAX31855Sensor::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up MAX31855Sensor '%s'...", this->name_.c_str());
+  this->spi_setup();
+}
+void MAX31855Sensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "MAX31855 '%s':", this->name_.c_str());
+  LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_UPDATE_INTERVAL(this);
+}
+float MAX31855Sensor::get_setup_priority() const {
+  return setup_priority::HARDWARE_LATE;
+}
+std::string MAX31855Sensor::unit_of_measurement() {
+  return UNIT_C;
+}
+std::string MAX31855Sensor::icon() {
+  return ICON_EMPTY;
+}
+int8_t MAX31855Sensor::accuracy_decimals() {
+  return 1;
+}
+void MAX31855Sensor::read_data_() {
+  this->enable();
+  delay(1);
+  uint8_t data[4];
+  this->read_array(data, 4);
+
+  // val is 14 bits of signed temperature data followed by 2 bits of status flags
+  int16_t val = data[1] | data[0] << 8;
+
+  // test data from MAX31855 datasheet
+  // val = 0x6400 // 1600.00°C
+  // val = 0x3E80 // 1000.00°C
+  // val = 0x064C // 100.75°C
+  // val = 0x0190 // 25.00°C
+  // val = 0x0000 // 0.00°C
+  // val = 0xFFFC // -0.25°C
+  // val = 0xFFF0 // -1.00°C
+  // val = 0xF060 // -250.00°C
+
+  this->disable();
+  if ((data[3] & 0x01) != 0) {
+    ESP_LOGW(TAG, "Got thermocouple not connected from MAX31855Sensor (0x%04X) (0x%04X)", val, data[3] | data[2] <<8);
+    this->status_set_warning();
+    return;
+  }
+  if ((data[3] & 0x02) != 0) {
+    ESP_LOGW(TAG, "Got short circuit to ground from MAX31855Sensor (0x%04X) (0x%04X)", val, data[3] | data[2] <<8);
+    this->status_set_warning();
+    return;
+  }
+  if ((data[3] & 0x04) != 0) {
+    ESP_LOGW(TAG, "Got short circuit to power from MAX31855Sensor (0x%04X) (0x%04X)", val, data[3] | data[2] <<8);
+    this->status_set_warning();
+    return;
+  }
+  if ((data[1] & 0x01) != 0) {
+    ESP_LOGW(TAG, "Got faulty reading from MAX31855Sensor (0x%04X) (0x%04X)", val, data[3] | data[2] <<8);
+    this->status_set_warning();
+    return;
+  }
+
+  if ((val & 0x8000) != 0) {
+    // Negative value, drop the lower 2 bits and explicitly extend sign bits.
+    val = 0xE000 | ((val >> 2) & 0x1FFF);
+  } else {
+    // Positive value, just drop the lower 2 bits.
+    val >>= 2;
+  }
+
+  float temperature = float(val) / 4.0f;
+  ESP_LOGD(TAG, "'%s': Got temperature=%.1f°C", this->name_.c_str(), temperature);
+  this->publish_state(temperature);
+  this->status_clear_warning();
+}
+
+MAX31855Sensor::MAX31855Sensor(const std::string &name, SPIComponent *parent, GPIOPin *cs, uint32_t update_interval)
+    : PollingSensorComponent(name, update_interval), SPIDevice(parent, cs) {}
+
+bool MAX31855Sensor::msb_first() {
+  return true;
+}
+
+} // namespace sensor
+
+ESPHOMELIB_NAMESPACE_END
+
+#endif //USE_MAX31855_SENSOR

--- a/src/esphomelib/sensor/max31855_sensor.h
+++ b/src/esphomelib/sensor/max31855_sensor.h
@@ -1,0 +1,41 @@
+#ifndef ESPHOMELIB_SENSOR_MAX31855_H
+#define ESPHOMELIB_SENSOR_MAX31855_H
+
+#include "esphomelib/defines.h"
+
+#ifdef USE_MAX31855_SENSOR
+
+#include "esphomelib/sensor/sensor.h"
+#include "esphomelib/spi_component.h"
+
+ESPHOMELIB_NAMESPACE_BEGIN
+
+namespace sensor {
+
+class MAX31855Sensor : public PollingSensorComponent, public SPIDevice {
+ public:
+  MAX31855Sensor(const std::string &name, SPIComponent *parent, GPIOPin *cs, uint32_t update_interval = 15000);
+
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+  void update() override;
+
+  std::string unit_of_measurement() override;
+  std::string icon() override;
+  int8_t accuracy_decimals() override;
+
+ protected:
+  bool msb_first() override;
+
+  void read_data_();
+};
+
+} // namespace sensor
+
+ESPHOMELIB_NAMESPACE_END
+
+#endif //USE_MAX31855_SENSOR
+
+#endif //ESPHOMELIB_SENSOR_MAX31855_H


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#97
**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#258
## Example entry for YAML configuration (if applicable):
```yaml
spi:
  miso_pin: GPIO13
  clk_pin: GPIO14
sensor:
  - platform: max31855
    name: Test Temperature
    cs_pin: GPIO12
```

## Checklist:
  - [✓] The code change is tested and works locally.
  - [✓] Check this box if you have read, understand, comply, and agree with the [Code of Conduct](https://github.com/OttoWinter/esphomelib/blob/master/CODE_OF_CONDUCT.md).

If user exposed functionality or configuration variables are added/changed:
  - [✓] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
