### PR TITLE
NeoPixelBus: fix handling of white color component

### DIFF
--- a/src/esphomelib/light/neo_pixel_bus_light_output.tcc
+++ b/src/esphomelib/light/neo_pixel_bus_light_output.tcc
@@ -77,9 +77,10 @@ void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::write_state(LightSta
   auto val = state->get_current_values();
   // don't use LightState helper, gamma correction+brightness is handled by ESPColorView
   ESPColor color = ESPColor(
-      uint8_t(roundf(val.get_red() * 255.0f)),
+      uint8_t(roundf(val.get_red()   * 255.0f)),
       uint8_t(roundf(val.get_green() * 255.0f)),
-      uint8_t(roundf(val.get_blue() * 255.0f))
+      uint8_t(roundf(val.get_blue()  * 255.0f)),
+      uint8_t(roundf(val.get_white() * 255.0f))
   );
 
   for (int i = 0; i < this->size(); i++) {


### PR DESCRIPTION
## Description:

NeoPixelBus does not handle the white color component (needed for RGBW strips) correctly.

## Checklist:
  - [X ] The code change is tested and works locally.