### PR TITLE
Throttle filter doesn't work for quick firing sensors

### DIFF
--- a/src/esphomelib/sensor/filter.cpp
+++ b/src/esphomelib/sensor/filter.cpp
@@ -180,7 +180,6 @@ optional<float> ThrottleFilter::new_value(float value) {
     this->last_input_ = now;
     return value;
   }
-  this->last_input_ = now;
   return {};
 }
 


### PR DESCRIPTION
I was debugging why the throttle didn't work for me. It filtered everything, never sending any updates except for the first one. 

By looking at the code, it seems that last_input_ gets pushed forward every time a new value comes in, even if it doesn't get published. That would mean that if you have a sensor that sends data every 1s but set it to throttle to 5s, the last_input_ gets updated every 1s and thus the time difference between last_input_ and now never reaches 5s.

Remove the update to last_input_ fixes the issue. 

Maybe we could take it one step further and rename that variable to last_update_ ? Because it contains the timestamp of the last value that made it trough, not the timestamp of the last value received, which the current name implies.

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
