### PR TITLE
Remove hard dependencies in library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -23,6 +23,16 @@
     {
       "name": "ArduinoJson-esphomelib",
       "version": "5.13.3"
+    },
+    {
+      "name": "ESPAsyncTCP",
+      "version": "1.1.3",
+      "platforms": "espressif8266"
+    },
+    {
+      "name": "AsyncTCP",
+      "version": "1.0.3",
+      "platforms": "espressif32"
     }
   ],
   "build": {

--- a/library.json
+++ b/library.json
@@ -23,18 +23,6 @@
     {
       "name": "ArduinoJson-esphomelib",
       "version": "5.13.3"
-    },
-    {
-      "name": "ESP Async WebServer",
-      "version": "1.1.1"
-    },
-    {
-      "name": "FastLED",
-      "version": "3.2.0"
-    },
-    {
-       "name": "NeoPixelBus",
-       "version": "2.4.1"
     }
   ],
   "build": {

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ build_flags =
 src_filter = +<src>
 
 [env:livingroom]
-platform = espressif32@1.5.0
+platform = espressif32@1.6.0
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -29,7 +29,7 @@ build_flags = ${common.build_flags} -DUSE_NEW_OTA -DUSE_ETHERNET
 src_filter = ${common.src_filter} +<examples/livingroom/livingroom.cpp>
 
 [env:dht-dallas-sensors]
-platform = espressif32@1.5.0
+platform = espressif32@1.6.0
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -37,7 +37,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/dht-dallas-sensors/dht-dallas-sensors.cpp>
 
 [env:switch-binarysensor]
-platform = espressif32@1.5.0
+platform = espressif32@1.6.0
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -45,7 +45,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/switch-binarysensor/switch-binarysensor.cpp>
 
 [env:fan-example]
-platform = espressif32@1.5.0
+platform = espressif32@1.6.0
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -53,7 +53,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/fan-example/fan-example.cpp>
 
 [env:lights]
-platform = espressif32@1.5.0
+platform = espressif32@1.6.0
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -79,7 +79,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/custom-bmp180-sensor/custom-bmp180-sensor.cpp>
 
 [env:i2c-sensors]
-platform = espressif32@1.5.0
+platform = espressif32@1.6.0
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -87,7 +87,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/i2c-sensors/i2c-sensors.cpp>
 
 [env:pcf8574]
-platform = espressif32@1.5.0
+platform = espressif32@1.6.0
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -95,7 +95,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/pcf8574/pcf8574.cpp>
 
 [env:fastled]
-platform = espressif32@1.5.0
+platform = espressif32@1.6.0
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -112,7 +112,7 @@ build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/sonoff-b1/sonoff-b1.cpp>
 
 [env:neopixelbus]
-platform = espressif32@1.5.0
+platform = espressif32@1.6.0
 board = nodemcu-32s
 framework = arduino
 lib_deps = ${common.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,8 @@ lib_deps =
     ESP Async WebServer@1.1.1
     FastLED@3.2.0
     NeoPixelBus@2.4.1
-    AsyncTCP@1.0.1
+    AsyncTCP@1.0.3
+    ESPAsyncTCP@1.1.3
 build_flags =
     -Wno-reorder
     -DUSE_WEB_SERVER

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,11 @@ lib_deps =
     FastLED@3.2.0
     NeoPixelBus@2.4.1
     AsyncTCP@1.0.1
-build_flags = -Wno-reorder
+build_flags =
+    -Wno-reorder
+    -DUSE_WEB_SERVER
+    -DUSE_FAST_LED_LIGHT
+    -DUSE_NEO_PIXEL_BUS_LIGHT
 src_filter = +<src>
 
 [env:livingroom]

--- a/src/esphomelib/defines.h
+++ b/src/esphomelib/defines.h
@@ -55,7 +55,6 @@
   #define USE_SHUTDOWN_SWITCH
   #define USE_FAN
   #define USE_DEBUG_COMPONENT
-  #define USE_WEB_SERVER
   #define USE_DEEP_SLEEP
   #define USE_PCF8574
   #define USE_IO
@@ -74,7 +73,6 @@
     #define USE_ESP32_BLE_TRACKER
     #define USE_ESP32_BLE_BEACON
   #endif
-  #define USE_FAST_LED_LIGHT
   #define USE_ROTARY_ENCODER_SENSOR
   #define USE_MAX31855_SENSOR
   #define USE_MAX6675_SENSOR
@@ -133,7 +131,6 @@
   #define USE_HOMEASSISTANT_SENSOR
   #define USE_HOMEASSISTANT_TEXT_SENSOR
   #define USE_APDS9960
-  #define USE_NEO_PIXEL_BUS_LIGHT
 #endif
 
 #ifdef USE_REMOTE_RECEIVER


### PR DESCRIPTION
## Description:

They're not required when using `ESPHOMELIB_USE`, and using esphomelib directly is being deprecated.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
