### PR TITLE
Fix GPIO switch restoring inverted

### DIFF
--- a/src/esphomelib/output/gpio_binary_output_component.cpp
+++ b/src/esphomelib/output/gpio_binary_output_component.cpp
@@ -19,8 +19,9 @@ void GPIOBinaryOutputComponent::write_state(bool state) {
 
 void GPIOBinaryOutputComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up GPIO Binary Output...");
+  this->turn_off();
   this->pin_->setup();
-  this->pin_->digital_write(false);
+  this->turn_off();
 }
 void GPIOBinaryOutputComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "GPIO Binary Output:");

--- a/src/esphomelib/switch_/gpio_switch.cpp
+++ b/src/esphomelib/switch_/gpio_switch.cpp
@@ -43,7 +43,7 @@ void GPIOSwitch::setup() {
   this->pin_->setup();
   // write after setup again for other IOs
   this->pin_->digital_write(initial_state != this->inverted_);
-  this->publish_state(initial_state);
+  this->publish_state(initial_state != this->inverted_);
 }
 void GPIOSwitch::dump_config() {
   LOG_SWITCH("", "GPIO Switch", this);


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
