### PR TITLE
Store log strings in flash for ESP8266

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,9 @@ build_flags =
     -DUSE_WEB_SERVER
     -DUSE_FAST_LED_LIGHT
     -DUSE_NEO_PIXEL_BUS_LIGHT
+    -DDONT_STORE_LOG_STR_IN_FLASH
+; Don't use FlashStringHelper for debug builds because CLion freaks out for all
+; log messages
 src_filter = +<src>
 
 [env:livingroom]

--- a/src/esphomelib/defines.h
+++ b/src/esphomelib/defines.h
@@ -621,4 +621,10 @@
   #endif
 #endif
 
+#if !defined(DONT_STORE_LOG_STR_IN_FLASH) && defined(ARDUINO_ARCH_ESP8266)
+  #ifndef USE_STORE_LOG_STR_IN_FLASH
+    #define USE_STORE_LOG_STR_IN_FLASH
+  #endif
+#endif
+
 #endif //ESPHOMELIB_DEFINES_H

--- a/src/esphomelib/log.cpp
+++ b/src/esphomelib/log.cpp
@@ -9,6 +9,15 @@ int HOT esp_log_printf_(int level, const char *tag, const char *format, ...) {
   va_end(arg);
   return ret;
 }
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+int HOT esp_log_printf_(int level, const char *tag, const __FlashStringHelper *format, ...) {
+  va_list arg;
+  va_start(arg, format);
+  int ret = esp_log_vprintf_(level, tag, format, arg);
+  va_end(arg);
+  return ret;
+}
+#endif
 
 int HOT esp_log_vprintf_(int level, const char *tag, const char *format, va_list args) {
   auto *log = esphomelib::global_log_component;
@@ -17,6 +26,16 @@ int HOT esp_log_vprintf_(int level, const char *tag, const char *format, va_list
 
   return log->log_vprintf_(level, tag, format, args);
 }
+
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+int HOT esp_log_vprintf_(int level, const char *tag, const __FlashStringHelper *format, va_list args) {
+  auto *log = esphomelib::global_log_component;
+  if (log == nullptr)
+    return 0;
+
+  return log->log_vprintf_(level, tag, format, args);
+}
+#endif
 
 int HOT esp_idf_log_vprintf_(const char *format, va_list args) {
   auto *log = esphomelib::global_log_component;

--- a/src/esphomelib/log.h
+++ b/src/esphomelib/log.h
@@ -4,6 +4,10 @@
 #include <cassert>
 #include <cstdarg>
 #include <string>
+#include "esphomelib/defines.h"
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  #include "WString.h"
+#endif
 
 // avoid esp-idf redefining our macros
 #include "esphomelib/esphal.h"
@@ -58,11 +62,20 @@
 #endif
 
 int esp_log_printf_(int level, const char *tag, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  int esp_log_printf_(int level, const char *tag, const __FlashStringHelper *format, ...);
+#endif
 int esp_log_vprintf_(int level, const char *tag, const char *format, va_list args);
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  int esp_log_vprintf_(int level, const char *tag, const __FlashStringHelper *format, va_list args);
+#endif
 int esp_idf_log_vprintf_(const char *format, va_list args);
 
-#define ESPHOMELIB_SHORT_LOG_FORMAT(tag, letter, format)  ESPHOMELIB_LOG_COLOR_ ## letter format ESPHOMELIB_LOG_RESET_COLOR
-#define ESPHOMELIB_LOG_FORMAT(tag, letter, format)  ESPHOMELIB_LOG_COLOR_ ## letter "[" #letter "][%s:%03u]: " format ESPHOMELIB_LOG_RESET_COLOR, tag, __LINE__
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  #define ESPHOMELIB_LOG_FORMAT(tag, letter, format)  F(ESPHOMELIB_LOG_COLOR_ ## letter "[" #letter "][%s:%03u]: " format ESPHOMELIB_LOG_RESET_COLOR), tag, __LINE__
+#else
+  #define ESPHOMELIB_LOG_FORMAT(tag, letter, format)  ESPHOMELIB_LOG_COLOR_ ## letter "[" #letter "][%s:%03u]: " format ESPHOMELIB_LOG_RESET_COLOR, tag, __LINE__
+#endif
 
 #if ESPHOMELIB_LOG_LEVEL >= ESPHOMELIB_LOG_LEVEL_VERY_VERBOSE
   #define esph_log_vv(tag, format, ...) esp_log_printf_(ESPHOMELIB_LOG_LEVEL_VERY_VERBOSE, tag, ESPHOMELIB_LOG_FORMAT(tag, VV, format), ##__VA_ARGS__)

--- a/src/esphomelib/log_component.h
+++ b/src/esphomelib/log_component.h
@@ -54,6 +54,11 @@ class LogComponent : public Component {
   size_t get_tx_buffer_size() const;
 
   int log_vprintf_(int level, const char *tag, const char *format, va_list args);
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  int log_vprintf_(int level, const char *tag, const __FlashStringHelper *format, va_list args);
+#endif
+  int level_for_(const char *tag);
+  void log_message_(int level, const char *tag, char *msg, int ret);
 
   /// Register a callback that will be called for every log message sent
   void add_on_log_callback(std::function<void(int, const char *, const char *)> &&callback);


### PR DESCRIPTION
## Description:

Saves about 10kb of RAM for an almost empty configuration for me.

Only applies to ESP8266 as ESP32 doesn't have flash storing functionality.

Disabled mode for direct esphomelib project because my IDEs freaking out otherwise.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
