### PR TITLE
Adding DHT model SI7021 to DHT sensor

### DIFF
--- a/src/esphomelib/sensor/dht_component.cpp
+++ b/src/esphomelib/sensor/dht_component.cpp
@@ -103,9 +103,14 @@ bool HOT DHTComponent::read_sensor_(float *temperature, float *humidity, bool re
 
   if (this->model_ == DHT_MODEL_DHT11)
     delayMicroseconds(18000);
+  else if (this->model_ == DHT_MODEL_SI7021) {
+    delayMicroseconds(500);
+    this->pin_->digital_write(true);
+    delayMicroseconds(40);
+  }
   else
     delayMicroseconds(800);
-
+  
   this->pin_->pin_mode(INPUT_PULLUP);
   delayMicroseconds(40);
 

--- a/src/esphomelib/sensor/dht_component.cpp
+++ b/src/esphomelib/sensor/dht_component.cpp
@@ -101,15 +101,15 @@ bool HOT DHTComponent::read_sensor_(float *temperature, float *humidity, bool re
   this->pin_->pin_mode(OUTPUT);
   this->pin_->digital_write(false);
 
-  if (this->model_ == DHT_MODEL_DHT11)
+  if (this->model_ == DHT_MODEL_DHT11) {
     delayMicroseconds(18000);
-  else if (this->model_ == DHT_MODEL_SI7021) {
+  } else if (this->model_ == DHT_MODEL_SI7021) {
     delayMicroseconds(500);
     this->pin_->digital_write(true);
     delayMicroseconds(40);
-  }
-  else
+  } else {
     delayMicroseconds(800);
+  }
   this->pin_->pin_mode(INPUT_PULLUP);
   delayMicroseconds(40);
 

--- a/src/esphomelib/sensor/dht_component.cpp
+++ b/src/esphomelib/sensor/dht_component.cpp
@@ -110,7 +110,6 @@ bool HOT DHTComponent::read_sensor_(float *temperature, float *humidity, bool re
   }
   else
     delayMicroseconds(800);
-  
   this->pin_->pin_mode(INPUT_PULLUP);
   delayMicroseconds(40);
 

--- a/src/esphomelib/sensor/dht_component.h
+++ b/src/esphomelib/sensor/dht_component.h
@@ -20,6 +20,7 @@ enum DHTModel {
   DHT_MODEL_DHT22,
   DHT_MODEL_AM2302,
   DHT_MODEL_RHT03,
+  DHT_MODEL_SI7021
 };
 
 /// Component for reading temperature/humidity measurements from DHT11/DHT22 sensors.
@@ -42,6 +43,7 @@ class DHTComponent : public PollingComponent {
    *  - DHT_MODEL_DHT22
    *  - DHT_MODEL_AM2302
    *  - DHT_MODEL_RHT03
+   *  - DHT_MODEL_SI7021
    *
    * @param model The DHT model.
    */


### PR DESCRIPTION
## Description:

Some one wire versions of SI7021 (distributed by Sonoff for their TH modules) requires a different initialization procedure to work. They use the same protocol as the DHT sensors.
I added the model for config validation purpose.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#375
**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#132

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
