### PR TITLE
Split off assumed state from optimistic mode

### DIFF
--- a/src/esphomelib/api/api.proto
+++ b/src/esphomelib/api/api.proto
@@ -120,7 +120,7 @@ message ListEntitiesCoverResponse {
   string name = 3;
   string unique_id = 4;
 
-  bool is_optimistic = 5;
+  bool assumed_state = 5;
 }
 message ListEntitiesFanResponse {
   string object_id = 1;
@@ -162,7 +162,7 @@ message ListEntitiesSwitchResponse {
   string unique_id = 4;
 
   string icon = 5;
-  bool optimistic = 6;
+  bool assumed_state = 6;
 }
 message ListEntitiesTextSensorResponse {
   string object_id = 1;

--- a/src/esphomelib/api/list_entities.cpp
+++ b/src/esphomelib/api/list_entities.cpp
@@ -33,8 +33,8 @@ bool ListEntitiesIterator::on_cover(cover::Cover *cover) {
     buffer.encode_nameable(cover);
     // string unique_id = 4;
     buffer.encode_string(4, get_default_unique_id("cover", cover));
-    // bool is_optimistic = 5;
-    buffer.encode_bool(5, cover->optimistic());
+    // bool assumed_state = 5;
+    buffer.encode_bool(5, cover->assumed_state());
   }, APIMessageType::LIST_ENTITIES_COVER_RESPONSE);
 }
 #endif
@@ -105,8 +105,8 @@ bool ListEntitiesIterator::on_switch(switch_::Switch *switch_) {
     buffer.encode_string(4, get_default_unique_id("switch", switch_));
     // string icon = 5;
     buffer.encode_string(5, switch_->get_icon());
-    // bool optimistic = 6;
-    buffer.encode_bool(6, switch_->optimistic());
+    // bool assumed_state = 6;
+    buffer.encode_bool(6, switch_->assumed_state());
   }, APIMessageType::LIST_ENTITIES_SWITCH_RESPONSE);
 }
 #endif

--- a/src/esphomelib/cover/cover.cpp
+++ b/src/esphomelib/cover/cover.cpp
@@ -20,7 +20,7 @@ void Cover::publish_state(CoverState state) {
   this->state = state;
   this->state_callback_.call(state);
 }
-bool Cover::optimistic() {
+bool Cover::assumed_state() {
   return false;
 }
 bool Cover::has_state() const {

--- a/src/esphomelib/cover/cover.h
+++ b/src/esphomelib/cover/cover.h
@@ -34,8 +34,8 @@ class StopAction;
 #define LOG_COVER(prefix, type, obj) \
     if (obj != nullptr) { \
       ESP_LOGCONFIG(TAG, prefix type " '%s'", obj->get_name().c_str()); \
-      if (obj->optimistic()) { \
-        ESP_LOGCONFIG(TAG, prefix "  Optimistic: YES"); \
+      if (obj->assumed_state()) { \
+        ESP_LOGCONFIG(TAG, prefix "  Assumed State: YES"); \
       } \
     }
 
@@ -63,7 +63,7 @@ class Cover : public Nameable {
    *
    * Defaults to false.
    */
-  virtual bool optimistic();
+  virtual bool assumed_state();
 
   CoverState state{COVER_OPEN};
 

--- a/src/esphomelib/cover/mqtt_cover_component.cpp
+++ b/src/esphomelib/cover/mqtt_cover_component.cpp
@@ -37,7 +37,7 @@ void MQTTCoverComponent::dump_config() {
   LOG_MQTT_COMPONENT(true, true)
 }
 void MQTTCoverComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig &config) {
-  if (this->cover_->optimistic())
+  if (this->cover_->assumed_state())
     root["optimistic"] = true;
 }
 

--- a/src/esphomelib/cover/template_cover.cpp
+++ b/src/esphomelib/cover/template_cover.cpp
@@ -22,17 +22,17 @@ void TemplateCover::loop() {
   auto s = (*this->f_)();
   if (!s.has_value())
     return;
-  if (this->last_state_.has_value() && *this->last_state_ == *s)
-    return;
 
   this->publish_state(*s);
-  this->last_state_ = *s;
 }
 void TemplateCover::set_optimistic(bool optimistic) {
   this->optimistic_ = optimistic;
 }
-bool TemplateCover::optimistic() {
-  return this->optimistic_;
+void TemplateCover::set_assumed_state(bool assumed_state) {
+  this->assumed_state_ = assumed_state;
+}
+bool TemplateCover::assumed_state() {
+  return this->assumed_state_;
 }
 void TemplateCover::set_state_lambda(std::function<optional<CoverState>()> &&f) {
   this->f_ = f;
@@ -55,17 +55,17 @@ void TemplateCover::write_command(CoverCommand command) {
   }
   switch (command) {
     case COVER_COMMAND_OPEN: {
-      if (this->optimistic_)
-        this->publish_state(COVER_OPEN);
       this->prev_trigger_ = this->open_trigger_;
       this->open_trigger_->trigger();
+      if (this->optimistic_)
+        this->publish_state(COVER_OPEN);
       break;
     }
     case COVER_COMMAND_CLOSE: {
-      if (this->optimistic_)
-        this->publish_state(COVER_CLOSED);
       this->prev_trigger_ = this->close_trigger_;
       this->close_trigger_->trigger();
+      if (this->optimistic_)
+        this->publish_state(COVER_CLOSED);
       break;
     }
     case COVER_COMMAND_STOP: {

--- a/src/esphomelib/cover/template_cover.h
+++ b/src/esphomelib/cover/template_cover.h
@@ -21,6 +21,7 @@ class TemplateCover : public Cover, public Component {
   Trigger<NoArg> *get_close_trigger() const;
   Trigger<NoArg> *get_stop_trigger() const;
   void set_optimistic(bool optimistic);
+  void set_assumed_state(bool assumed_state);
 
   void loop() override;
   void dump_config() override;
@@ -29,15 +30,15 @@ class TemplateCover : public Cover, public Component {
 
  protected:
   void write_command(CoverCommand command) override;
-  bool optimistic() override;
+  bool assumed_state() override;
 
   optional<std::function<optional<CoverState>()>> f_;
+  bool assumed_state_{false};
   bool optimistic_{false};
   Trigger<NoArg> *open_trigger_;
   Trigger<NoArg> *close_trigger_;
   Trigger<NoArg> *stop_trigger_;
   Trigger<NoArg> *prev_trigger_{nullptr};
-  optional<CoverState> last_state_;
 };
 
 } // namespace cover

--- a/src/esphomelib/switch_/mqtt_switch_component.cpp
+++ b/src/esphomelib/switch_/mqtt_switch_component.cpp
@@ -55,7 +55,7 @@ std::string MQTTSwitchComponent::component_type() const {
 void MQTTSwitchComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig &config) {
   if (!this->switch_->get_icon().empty())
     root["icon"] = this->switch_->get_icon();
-  if (this->switch_->optimistic())
+  if (this->switch_->assumed_state())
     root["optimistic"] = true;
 }
 bool MQTTSwitchComponent::send_initial_state() {

--- a/src/esphomelib/switch_/switch.cpp
+++ b/src/esphomelib/switch_/switch.cpp
@@ -55,7 +55,7 @@ void Switch::publish_state(bool state) {
   ESP_LOGD(TAG, "'%s': Sending state %s", this->name_.c_str(), ONOFF(state));
   this->state_callback_.call(this->state);
 }
-bool Switch::optimistic() {
+bool Switch::assumed_state() {
   return false;
 }
 

--- a/src/esphomelib/switch_/switch.h
+++ b/src/esphomelib/switch_/switch.h
@@ -29,8 +29,8 @@ class SwitchCondition;
       if (!obj->get_icon().empty()) { \
         ESP_LOGCONFIG(TAG, prefix "  Icon: '%s'", obj->get_icon().c_str()); \
       } \
-      if (obj->optimistic()) { \
-        ESP_LOGCONFIG(TAG, prefix "  Optimistic: YES"); \
+      if (obj->assumed_state()) { \
+        ESP_LOGCONFIG(TAG, prefix "  Assumed State: YES"); \
       } \
       if (obj->is_inverted()) { \
         ESP_LOGCONFIG(TAG, prefix "  Inverted: YES"); \
@@ -113,12 +113,12 @@ class Switch : public Nameable {
 
   optional<bool> get_initial_state();
 
-  /** Return whether this switch is optimistic - i.e. if both the ON/OFF actions should be displayed in Home Assistant
+  /** Return whether this switch uses an assumed state - i.e. if both the ON/OFF actions should be displayed in Home Assistant
    * because the real state is unknown.
    *
    * Defaults to false.
    */
-  virtual bool optimistic();
+  virtual bool assumed_state();
 
   bool is_inverted() const;
 

--- a/src/esphomelib/switch_/template_switch.cpp
+++ b/src/esphomelib/switch_/template_switch.cpp
@@ -47,7 +47,7 @@ void TemplateSwitch::write_state(bool state) {
 void TemplateSwitch::set_optimistic(bool optimistic) {
   this->optimistic_ = optimistic;
 }
-bool TemplateSwitch::optimistic() {
+bool TemplateSwitch::assumed_state() {
   return this->optimistic_;
 }
 void TemplateSwitch::set_state_lambda(std::function<optional<bool>()> &&f) {
@@ -80,9 +80,13 @@ void TemplateSwitch::setup() {
 void TemplateSwitch::dump_config() {
   LOG_SWITCH("", "Template Switch", this);
   ESP_LOGCONFIG(TAG, "  Restore State: %s", YESNO(this->restore_state_));
+  ESP_LOGCONFIG(TAG, "  Optimistic: %s", YESNO(this->optimistic_));
 }
 void TemplateSwitch::set_restore_state(bool restore_state) {
   this->restore_state_ = restore_state;
+}
+void TemplateSwitch::set_assumed_state(bool assumed_state) {
+  this->assumed_state_ = assumed_state;
 }
 
 } // namespace switch_

--- a/src/esphomelib/switch_/template_switch.h
+++ b/src/esphomelib/switch_/template_switch.h
@@ -24,18 +24,20 @@ class TemplateSwitch : public Switch, public Component {
   Trigger<NoArg> *get_turn_on_trigger() const;
   Trigger<NoArg> *get_turn_off_trigger() const;
   void set_optimistic(bool optimistic);
+  void set_assumed_state(bool assumed_state);
   void loop() override;
 
   float get_setup_priority() const override;
 
  protected:
-  bool optimistic() override;
+  bool assumed_state() override;
 
   void write_state(bool state) override;
 
   optional<std::function<optional<bool>()>> f_;
   bool optimistic_{false};
   optional<bool> last_state_{};
+  bool assumed_state_{false};
   Trigger<NoArg> *turn_on_trigger_;
   Trigger<NoArg> *turn_off_trigger_;
   Trigger<NoArg> *prev_trigger_{nullptr};


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#394
**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
