### PR TITLE
Update sony.cpp to fix incorrectly formed Sony IR code (extra bit)

### DIFF
--- a/src/esphomelib/remote/sony.cpp
+++ b/src/esphomelib/remote/sony.cpp
@@ -34,7 +34,7 @@ void encode_sony(RemoteTransmitData *data, uint32_t data_, uint8_t nbits) {
 
   data->item(HEADER_HIGH_US, HEADER_LOW_US);
 
-  for (uint32_t mask = 1UL << (nbits); mask != 0; mask >>= 1) {
+  for (uint32_t mask = 1UL << (nbits - 1); mask != 0; mask >>= 1) {
     if (data_ & mask)
       data->item(BIT_ONE_HIGH_US, BIT_LOW_US);
     else


### PR DESCRIPTION
Modified as per https://github.com/esphome/ESPHome/issues/387 to fix incorrect Sony code creation.

## Description:

As discussed in the description I have found an error in the sony.cpp code which is used to create the IR codes. The decoding part works OK but the encode adds an extra bit to the 12 bits that are required. I haven't exhaustively tested the patch with other Sony devices or with 15 bit codes.

Sorry if I haven't provided enough detail or done enough testing this is my first ever attempt at using GitHub.

**Related issue (if applicable):** fixes <https://github.com/esphome/ESPHome/issues/387>

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#<esphomeyaml PR number goes here>
**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#<esphomedocs PR number goes here>

## Checklist:
  - [yes ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [no ] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).

I would be happy to expand the documentation around IR transmit codes specifically when using a Sony remote.
