### PR TITLE
Remove 'flash' property from MQTT Light discovery JSON.

### DIFF
--- a/src/esphomelib/light/mqtt_json_light_component.cpp
+++ b/src/esphomelib/light/mqtt_json_light_component.cpp
@@ -50,7 +50,6 @@ void MQTTJSONLightComponent::send_discovery(JsonObject &root, mqtt::SendDiscover
     root["rgb"] = true;
   if (this->state_->get_traits().has_color_temperature())
     root["color_temp"] = true;
-  root["flash"] = true;
   if (this->state_->get_traits().has_rgb_white_value())
     root["white_value"] = true;
   if (this->state_->supports_effects()) {


### PR DESCRIPTION
## Description:
Remove invalid/unused 'flash' attribute from MQTT lights. I might be missing something, but I don't see that any special configuration is necessary to indicate support for flashing.

**Related issue (if applicable):**
Fixes #477


## Checklist:
  - [ ] The code change is tested and works locally.