### PR TITLE
Enable use of alternate hardware UARTs for logging

### DIFF
--- a/src/esphomelib/application.cpp
+++ b/src/esphomelib/application.cpp
@@ -197,8 +197,9 @@ MQTTClientComponent *Application::init_mqtt(const std::string &address,
 #endif
 
 LogComponent *Application::init_log(uint32_t baud_rate,
-                                    size_t tx_buffer_size) {
-  auto *log = new LogComponent(baud_rate, tx_buffer_size);
+                                    size_t tx_buffer_size,
+                                    UARTSelection uart) {
+  auto *log = new LogComponent(baud_rate, tx_buffer_size, uart);
   log->pre_setup();
   return this->register_component(log);
 }

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -162,10 +162,12 @@ class Application {
    *
    * @param baud_rate The serial baud rate. Set to 0 to disable UART debugging.
    * @param tx_buffer_size The size of the printf buffer.
+   * @param hw_serial The hardware serial UART used for logging.
    * @return The created and initialized LogComponent.
    */
   LogComponent *init_log(uint32_t baud_rate = 115200,
-                         size_t tx_buffer_size = 512);
+                         size_t tx_buffer_size = 512,
+                         UARTSelection uart = ESPHOMELIB_UART0);
 
   /** Initialize the WiFi engine in client mode.
    *

--- a/src/esphomelib/application.h
+++ b/src/esphomelib/application.h
@@ -167,7 +167,7 @@ class Application {
    */
   LogComponent *init_log(uint32_t baud_rate = 115200,
                          size_t tx_buffer_size = 512,
-                         UARTSelection uart = ESPHOMELIB_UART0);
+                         UARTSelection uart = UART_SELECTION_UART0);
 
   /** Initialize the WiFi engine in client mode.
    *

--- a/src/esphomelib/log_component.cpp
+++ b/src/esphomelib/log_component.cpp
@@ -146,10 +146,17 @@ float LogComponent::get_setup_priority() const {
   return setup_priority::HARDWARE - 1.0f;
 }
 const char *LOG_LEVELS[] = {"NONE", "ERROR", "WARN", "INFO", "DEBUG", "VERBOSE", "VERY_VERBOSE"};
+#ifdef ARDUINO_ARCH_ESP32
+const char *UART_SELECTIONS[] = {"UART0", "UART1", "UART2"};
+#endif
+#ifdef ARDUINO_ARCH_ESP8266
+const char *UART_SELECTIONS[] = {"UART0", "UART1", "UART0_SWAP"};
+#endif
 void LogComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Logger:");
   ESP_LOGCONFIG(TAG, "  Level: %s", LOG_LEVELS[this->global_log_level_]);
   ESP_LOGCONFIG(TAG, "  Log Baud Rate: %u", this->baud_rate_);
+  ESP_LOGCONFIG(TAG, "  Hardware UART: %s", UART_SELECTIONS[this->uart_]);
   for (auto &it : this->log_levels_) {
     ESP_LOGCONFIG(TAG, "  Level for '%s': %s", it.tag.c_str(), LOG_LEVELS[it.level]);
   }

--- a/src/esphomelib/log_component.cpp
+++ b/src/esphomelib/log_component.cpp
@@ -80,17 +80,17 @@ LogComponent::LogComponent(uint32_t baud_rate, size_t tx_buffer_size, UARTSelect
 
 void LogComponent::pre_setup() {
   switch (this->uart_) {
-    case ESPHOMELIB_UART0:
+    case UART_SELECTION_UART0:
 #ifdef ARDUINO_ARCH_ESP8266
-    case ESPHOMELIB_UART0_SWAP:
+    case UART_SELECTION_UART0_SWAP:
 #endif
       this->hw_serial_ = &Serial;
       break;
-    case ESPHOMELIB_UART1:
+    case UART_SELECTION_UART1:
       this->hw_serial_ = &Serial1;
       break;
 #ifdef ARDUINO_ARCH_ESP32
-    case ESPHOMELIB_UART2:
+    case UART_SELECTION_UART2:
       this->hw_serial_ = &Serial2;
       break;
 #endif
@@ -98,7 +98,7 @@ void LogComponent::pre_setup() {
 
   this->hw_serial_->begin(this->baud_rate_);
 #ifdef ARDUINO_ARCH_ESP8266
-  if (this->uart_ == ESPHOMELIB_UART0_SWAP)
+  if (this->uart_ == UART_SELECTION_UART0_SWAP)
     this->hw_serial_->swap();
 #endif
 

--- a/src/esphomelib/log_component.cpp
+++ b/src/esphomelib/log_component.cpp
@@ -68,18 +68,39 @@ void HOT LogComponent::log_message_(int level, const char *tag, char *msg, int r
     msg[ret - 1] = '\0';
   }
   if (this->baud_rate_ > 0)
-    Serial.println(msg);
+    this->hw_serial_->println(msg);
   this->log_callback_.call(level, tag, msg);
 }
 
-LogComponent::LogComponent(uint32_t baud_rate, size_t tx_buffer_size)
-    : baud_rate_(baud_rate) {
+LogComponent::LogComponent(uint32_t baud_rate, size_t tx_buffer_size, UARTSelection uart)
+    : baud_rate_(baud_rate)
+    , uart_(uart) {
   this->set_tx_buffer_size(tx_buffer_size);
 }
 
 void LogComponent::pre_setup() {
-  if (this->baud_rate_ > 0)
-    Serial.begin(this->baud_rate_);
+  switch (this->uart_) {
+    case ESPHOMELIB_UART0:
+#ifdef ARDUINO_ARCH_ESP8266
+    case ESPHOMELIB_UART0_SWAP:
+#endif
+      this->hw_serial_ = &Serial;
+      break;
+    case ESPHOMELIB_UART1:
+      this->hw_serial_ = &Serial1;
+      break;
+#ifdef ARDUINO_ARCH_ESP32
+    case ESPHOMELIB_UART2:
+      this->hw_serial_ = &Serial2;
+      break;
+#endif
+  }
+
+  this->hw_serial_->begin(this->baud_rate_);
+#ifdef ARDUINO_ARCH_ESP8266
+  if (this->uart_ == ESPHOMELIB_UART0_SWAP)
+    this->hw_serial_->swap();
+#endif
 
   global_log_component = this;
 #ifdef ARDUINO_ARCH_ESP32
@@ -91,7 +112,7 @@ void LogComponent::pre_setup() {
 #ifdef ARDUINO_ARCH_ESP8266
   if (this->global_log_level_ >= ESPHOMELIB_LOG_LEVEL_VERBOSE) {
     if (this->baud_rate_ > 0)
-      Serial.setDebugOutput(true);
+      this->hw_serial_->setDebugOutput(true);
   }
 #endif
 
@@ -114,6 +135,9 @@ size_t LogComponent::get_tx_buffer_size() const {
 }
 void LogComponent::set_tx_buffer_size(size_t tx_buffer_size) {
   this->tx_buffer_.reserve(tx_buffer_size);
+}
+UARTSelection LogComponent::get_uart() const {
+  return this->uart_;
 }
 void LogComponent::add_on_log_callback(std::function<void(int, const char *, const char *)> &&callback) {
   this->log_callback_.add(std::move(callback));

--- a/src/esphomelib/log_component.h
+++ b/src/esphomelib/log_component.h
@@ -17,6 +17,22 @@
 
 ESPHOMELIB_NAMESPACE_BEGIN
 
+/** Enum for logging UART selection
+ *
+ * Advanced configuration (pin selection, etc) is not supported.
+ */
+enum UARTSelection {
+  ESPHOMELIB_UART0 = 0,
+  ESPHOMELIB_UART1,
+#ifdef ARDUINO_ARCH_ESP32
+  ESPHOMELIB_UART2
+#endif
+#ifdef ARDUINO_ARCH_ESP8266
+  ESPHOMELIB_UART0_SWAP
+#endif
+};
+
+
 /** A simple component that enables logging to Serial via the ESP_LOG* macros.
  *
  * This component should optimally be setup very early because only after its setup log messages are actually sent.
@@ -29,13 +45,16 @@ class LogComponent : public Component {
    * @param baud_rate The baud_rate for the serial interface. 0 to disable UART logging.
    * @param tx_buffer_size The buffer size (in bytes) used for constructing log messages.
    */
-  explicit LogComponent(uint32_t baud_rate = 11520, size_t tx_buffer_size = 512);
+  explicit LogComponent(uint32_t baud_rate = 115200, size_t tx_buffer_size = 512, UARTSelection uart = ESPHOMELIB_UART0);
 
   /// Manually set the baud rate for serial, set to 0 to disable.
   void set_baud_rate(uint32_t baud_rate);
 
   /// Set the buffer size that's used for constructing log messages. Log messages longer than this will be truncated.
   void set_tx_buffer_size(size_t tx_buffer_size);
+
+  /// Get the UART used by the logger.
+  UARTSelection get_uart() const;
 
   /// Set the global log level. Note: Use the ESPHOMELIB_LOG_LEVEL define to also remove the logs from the build.
   void set_global_log_level(int log_level);
@@ -68,6 +87,8 @@ class LogComponent : public Component {
  protected:
   uint32_t baud_rate_;
   std::vector<char> tx_buffer_;
+  UARTSelection uart_{ESPHOMELIB_UART0};
+  HardwareSerial *hw_serial_{nullptr};
   int global_log_level_{ESPHOMELIB_LOG_LEVEL};
   struct LogLevelOverride {
     std::string tag;

--- a/src/esphomelib/log_component.h
+++ b/src/esphomelib/log_component.h
@@ -22,13 +22,13 @@ ESPHOMELIB_NAMESPACE_BEGIN
  * Advanced configuration (pin selection, etc) is not supported.
  */
 enum UARTSelection {
-  ESPHOMELIB_UART0 = 0,
-  ESPHOMELIB_UART1,
+  UART_SELECTION_UART0 = 0,
+  UART_SELECTION_UART1,
 #ifdef ARDUINO_ARCH_ESP32
-  ESPHOMELIB_UART2
+  UART_SELECTION_UART2
 #endif
 #ifdef ARDUINO_ARCH_ESP8266
-  ESPHOMELIB_UART0_SWAP
+  UART_SELECTION_UART0_SWAP
 #endif
 };
 
@@ -45,7 +45,7 @@ class LogComponent : public Component {
    * @param baud_rate The baud_rate for the serial interface. 0 to disable UART logging.
    * @param tx_buffer_size The buffer size (in bytes) used for constructing log messages.
    */
-  explicit LogComponent(uint32_t baud_rate = 115200, size_t tx_buffer_size = 512, UARTSelection uart = ESPHOMELIB_UART0);
+  explicit LogComponent(uint32_t baud_rate = 115200, size_t tx_buffer_size = 512, UARTSelection uart = UART_SELECTION_UART0);
 
   /// Manually set the baud rate for serial, set to 0 to disable.
   void set_baud_rate(uint32_t baud_rate);
@@ -87,7 +87,7 @@ class LogComponent : public Component {
  protected:
   uint32_t baud_rate_;
   std::vector<char> tx_buffer_;
-  UARTSelection uart_{ESPHOMELIB_UART0};
+  UARTSelection uart_{UART_SELECTION_UART0};
   HardwareSerial *hw_serial_{nullptr};
   int global_log_level_{ESPHOMELIB_LOG_LEVEL};
   struct LogLevelOverride {

--- a/src/esphomelib/uart_component.cpp
+++ b/src/esphomelib/uart_component.cpp
@@ -36,9 +36,9 @@ void UARTComponent::setup() {
   if (this->tx_pin_.value_or(1) == 1 && this->rx_pin_.value_or(3) == 3) {
     this->hw_serial_ = &Serial;
   } else if (this->tx_pin_.value_or(9) == 9 && this->rx_pin_.value_or(10) == 10) {
-    this->hw_serial = &Serial1;
+    this->hw_serial_ = &Serial1;
   } else if (this->tx_pin_.value_or(16) == 16 && this->rx_pin_.value_or(17) == 17) {
-    this->hw_serial = &Serial2;
+    this->hw_serial_ = &Serial2;
   } else {
     this->hw_serial_ = new HardwareSerial(next_uart_num++);
   }

--- a/src/esphomelib/uart_component.cpp
+++ b/src/esphomelib/uart_component.cpp
@@ -126,16 +126,13 @@ void UARTComponent::setup() {
   if (this->tx_pin_.value_or(1) == 1 && this->rx_pin_.value_or(3) == 3) {
     this->hw_serial_ = &Serial;
     this->hw_serial_->begin(this->baud_rate_);
-    this->hw_serial_->setDebugOutput(false);
   } else if (this->tx_pin_.value_or(15) == 15 && this->rx_pin_.value_or(13) == 13) {
     this->hw_serial_ = &Serial;
     this->hw_serial_->begin(this->baud_rate_);
-    this->hw_serial_->setDebugOutput(false);
     this->hw_serial_->swap();
   } else if (this->tx_pin_.value_or(2) == 2 && this->rx_pin_.value_or(8) == 8) {
     this->hw_serial_ = &Serial1;
     this->hw_serial_->begin(this->baud_rate_);
-    this->hw_serial_->setDebugOutput(false);
   } else {
     this->sw_serial_ = new ESP8266SoftwareSerial();
     int8_t tx = this->tx_pin_.has_value() ? *this->tx_pin_ : -1;

--- a/src/esphomelib/uart_component.cpp
+++ b/src/esphomelib/uart_component.cpp
@@ -30,10 +30,15 @@ float UARTComponent::get_setup_priority() const {
 #ifdef ARDUINO_ARCH_ESP32
 void UARTComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up UART...");
+  // Use Arduino HardwareSerial UARTs if all used pins match the ones
+  // preconfigured by the platform. For example if RX disabled but TX pin
+  // is 1 we still want to use Serial.
   if (this->tx_pin_.value_or(1) == 1 && this->rx_pin_.value_or(3) == 3) {
-    // use UART0 if all used pins match the ones on the UART bus
-    // for example if RX disabled but TX pin is 1 we still want to use Serial.
     this->hw_serial_ = &Serial;
+  } else if (this->tx_pin_.value_or(9) == 9 && this->rx_pin_.value_or(10) == 10) {
+    this->hw_serial = &Serial1;
+  } else if (this->tx_pin_.value_or(16) == 16 && this->rx_pin_.value_or(17) == 17) {
+    this->hw_serial = &Serial2;
   } else {
     this->hw_serial_ = new HardwareSerial(next_uart_num++);
   }
@@ -115,10 +120,18 @@ void UARTComponent::flush() {
 #ifdef ARDUINO_ARCH_ESP8266
 void UARTComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up UART bus...");
+  // Use Arduino HardwareSerial UARTs if all used pins match the ones
+  // preconfigured by the platform. For example if RX disabled but TX pin
+  // is 1 we still want to use Serial.
   if (this->tx_pin_.value_or(1) == 1 && this->rx_pin_.value_or(3) == 3) {
-    // use UART0 if all used pins match the ones on the UART bus
-    // for example if RX disabled but TX pin is 1 we still want to use Serial.
     this->hw_serial_ = &Serial;
+    this->hw_serial_->begin(this->baud_rate_);
+  } else if (this->tx_pin_.value_or(15) == 15 && this->rx_pin_.value_or(13) == 13) {
+    this->hw_serial_ = &Serial;
+    this->hw_serial_->begin(this->baud_rate_);
+    this->hw_serial_->swap();
+  } else if (this->tx_pin_.value_or(2) == 2 && this->rx_pin_.value_or(8) == 8) {
+    this->hw_serial_ = &Serial1;
     this->hw_serial_->begin(this->baud_rate_);
   } else {
     this->sw_serial_ = new ESP8266SoftwareSerial();

--- a/src/esphomelib/uart_component.cpp
+++ b/src/esphomelib/uart_component.cpp
@@ -126,13 +126,16 @@ void UARTComponent::setup() {
   if (this->tx_pin_.value_or(1) == 1 && this->rx_pin_.value_or(3) == 3) {
     this->hw_serial_ = &Serial;
     this->hw_serial_->begin(this->baud_rate_);
+    this->hw_serial_->setDebugOutput(false);
   } else if (this->tx_pin_.value_or(15) == 15 && this->rx_pin_.value_or(13) == 13) {
     this->hw_serial_ = &Serial;
     this->hw_serial_->begin(this->baud_rate_);
+    this->hw_serial_->setDebugOutput(false);
     this->hw_serial_->swap();
   } else if (this->tx_pin_.value_or(2) == 2 && this->rx_pin_.value_or(8) == 8) {
     this->hw_serial_ = &Serial1;
     this->hw_serial_->begin(this->baud_rate_);
+    this->hw_serial_->setDebugOutput(false);
   } else {
     this->sw_serial_ = new ESP8266SoftwareSerial();
     int8_t tx = this->tx_pin_.has_value() ? *this->tx_pin_ : -1;


### PR DESCRIPTION
## Description:
Enable use of Serial1 on ESP8266 and Serial1/Serial2 on ESP32 for logging.
This is frequently done on ESP8266 to allow use of Serial for UART TX+RX,
while  maintaining logging output on Serial1 which is TX-only via GPIO2.

**Pull request in [esphomeyaml](https://github.com/OttoWinter/esphomeyaml) with YAML changes (if applicable):** OttoWinter/esphomeyaml#427
**Pull request in [esphomedocs](https://github.com/OttoWinter/esphomedocs) with documentation (if applicable):** OttoWinter/esphomedocs#161

## Checklist:
  - [X] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphomedocs](https://github.com/OttoWinter/esphomedocs).
