### PR TITLE
Template switch do not restore state by default

### DIFF
--- a/src/esphome/switch_/template_switch.h
+++ b/src/esphome/switch_/template_switch.h
@@ -40,7 +40,7 @@ class TemplateSwitch : public Switch, public Component {
   Trigger<NoArg> *turn_on_trigger_;
   Trigger<NoArg> *turn_off_trigger_;
   Trigger<NoArg> *prev_trigger_{nullptr};
-  bool restore_state_{true};
+  bool restore_state_{false};
 };
 
 } // namespace switch_


### PR DESCRIPTION
## Description:

That behavior was always weird

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
