### PR TITLE
Fix ethernet initialization order

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This is the source of the C++ library that powers [ESPHome](https://esphome.io/)
 
 For issues, please go to [the issue tracker](https://github.com/esphome/issues/issues).
+
 For feature requests, please see [feature requests](https://github.com/esphome/feature-requests/issues).
 
 > Note: Starting with 1.10.0 using ESPHome-Core directly through C++ is no longer officially


### PR DESCRIPTION
ethernet interface must be started before TCP settings

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
