### PR TITLE
Add empty nameable constructors

### DIFF
--- a/src/esphome/switch_/switch.cpp
+++ b/src/esphome/switch_/switch.cpp
@@ -15,10 +15,8 @@ static const char *TAG = "switch";
 std::string Switch::icon() {
   return "";
 }
-Switch::Switch(const std::string &name)
-  : Nameable(name), state(false) {
-
-}
+Switch::Switch(const std::string &name) : Nameable(name), state(false) {}
+Switch::Switch() : Switch("") {}
 
 std::string Switch::get_icon() {
   if (this->icon_.has_value())

--- a/src/esphome/switch_/switch.h
+++ b/src/esphome/switch_/switch.h
@@ -51,6 +51,7 @@ class MQTTSwitchComponent;
  */
 class Switch : public Nameable {
  public:
+  explicit Switch();
   explicit Switch(const std::string &name);
 
   /** Publish a state to the front-end from the back-end.

--- a/src/esphome/text_sensor/text_sensor.cpp
+++ b/src/esphome/text_sensor/text_sensor.cpp
@@ -11,6 +11,9 @@ namespace text_sensor {
 
 static const char *TAG = "text_sensor.text_sensor";
 
+TextSensor::TextSensor() : TextSensor("") {}
+TextSensor::TextSensor(const std::string &name) : Nameable(name) {}
+
 void TextSensor::publish_state(std::string state) {
   this->state = state;
   this->has_state_ = true;

--- a/src/esphome/text_sensor/text_sensor.h
+++ b/src/esphome/text_sensor/text_sensor.h
@@ -34,7 +34,8 @@ class MQTTTextSensor;
 
 class TextSensor : public Nameable {
  public:
-  explicit TextSensor(const std::string &name) : Nameable(name) {}
+  explicit TextSensor();
+  explicit TextSensor(const std::string &name);
 
   void publish_state(std::string state);
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
