### PR TITLE
Fix Waveshare 7.5in EPaper WDT reset issue

### DIFF
--- a/src/esphome/display/waveshare_epaper.cpp
+++ b/src/esphome/display/waveshare_epaper.cpp
@@ -84,6 +84,13 @@ void WaveshareEPaper::data(uint8_t value) {
   this->write_byte(value);
   this->disable();
 }
+void WaveshareEPaper::start_data() {
+  this->dc_pin_->digital_write(true);
+  this->enable();
+}
+void WaveshareEPaper::stop_data() {
+  this->disable();
+}
 bool WaveshareEPaper::msb_first() {
   return true;
 }
@@ -641,6 +648,7 @@ void WaveshareEPaper7P5In::setup() {
 }
 void HOT WaveshareEPaper7P5In::display() {
   this->command(WAVESHARE_EPAPER_B_COMMAND_DATA_START_TRANSMISSION_1);
+  this->start_data();
   for (size_t i = 0; i < this->get_buffer_length(); i++) {
     uint8_t temp1 = this->buffer_[i];
     for (uint8_t j = 0; j < 8; j++) {
@@ -658,11 +666,12 @@ void HOT WaveshareEPaper7P5In::display() {
       else
         temp2 |= 0x00;
       temp1 <<= 1;
-      this->data(temp2);
+      this->write_byte(temp2);
     }
 
     feed_wdt();
   }
+  this->stop_data();
   this->command(WAVESHARE_EPAPER_B_COMMAND_DISPLAY_REFRESH);
 }
 int WaveshareEPaper7P5In::get_width_internal_() {

--- a/src/esphome/display/waveshare_epaper.h
+++ b/src/esphome/display/waveshare_epaper.h
@@ -22,6 +22,8 @@ class WaveshareEPaper : public PollingComponent, public SPIDevice, public Displa
   bool msb_first() override;
   void command(uint8_t value);
   void data(uint8_t value);
+  void start_data();
+  void stop_data();
   bool wait_until_idle_();
 
   virtual void display() = 0;


### PR DESCRIPTION
## Description:
Fixes the WDT reset issue with Waveshare 7.5" EPaper displays

**Related issue (if applicable):** fixes esphome/issues#62

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
