### PR TITLE
Add logic in Output for minimum power setting

### DIFF
--- a/src/esphome/output/float_output.cpp
+++ b/src/esphome/output/float_output.cpp
@@ -12,11 +12,19 @@ ESPHOME_NAMESPACE_BEGIN
 namespace output {
 
 void FloatOutput::set_max_power(float max_power) {
-  this->max_power_ = clamp(0.0f, 1.0f, max_power);
+  this->max_power_ = clamp(this->min_power_, 1.0f, max_power); // Clamp to MIN>=MAX>=1.0
 }
 
 float FloatOutput::get_max_power() const {
   return this->max_power_;
+}
+
+void FloatOutput::set_min_power(float min_power) {
+  this->min_power_ = clamp(0.0f, this->max_power_, min_power); // Clamp to 0.0>=MIN>=MAX
+}
+
+float FloatOutput::get_min_power() const {
+  return this->min_power_;
 }
 
 void FloatOutput::set_level(float state) {
@@ -35,7 +43,7 @@ void FloatOutput::set_level(float state) {
     }
   }
 
-  float adjusted_value =  state * this->max_power_;
+  float adjusted_value =  (state * (this->max_power_ - this->min_power_)) + this->min_power_;
   if (this->is_inverted())
     adjusted_value = 1.0f - adjusted_value;
   this->write_state(adjusted_value);

--- a/src/esphome/output/float_output.h
+++ b/src/esphome/output/float_output.h
@@ -17,7 +17,8 @@ class SetLevelAction;
 
 #define LOG_FLOAT_OUTPUT(this) \
   LOG_BINARY_OUTPUT(this) \
-  if (this->max_power_ != 1.0f) { ESP_LOGCONFIG(TAG, "  Max Power: %.1f%%", this->max_power_ * 100.0f); }
+  if (this->max_power_ != 1.0f) { ESP_LOGCONFIG(TAG, "  Max Power: %.1f%%", this->max_power_ * 100.0f); } \
+  if (this->min_power_ != 0.0f) { ESP_LOGCONFIG(TAG, "  Min Power: %.1f%%", this->min_power_ * 100.0f); }
 
 /** Base class for all output components that can output a variable level, like PWM.
  *
@@ -26,21 +27,29 @@ class SetLevelAction;
  * makes using maths much easier and (in theory) supports all possible bit depths.
  *
  * If you want to create a FloatOutput yourself, you essentially just have to override write_state(float).
- * That method will be called for you with inversion and max power already applied. It is
+ * That method will be called for you with inversion and max-min power and offset to min power already applied.
  *
  * This interface is compatible with BinaryOutput (and will automatically convert the binary states to floating
- * point states for you). Additionally, this class provides a way for users to set a maximum power
+ * point states for you). Additionally, this class provides a way for users to set a minimum and/or maximum power
  * output
  */
 class FloatOutput : public BinaryOutput {
  public:
   /** Set the maximum power output of this component.
    *
-   * All values are multiplied by this float to get the adjusted value.
+   * All values are multiplied by max_power - min_power and offset to min_power to get the adjusted value.
    *
-   * @param max_power Automatically clamped from 0 to 1.
+   * @param max_power Automatically clamped from 0 or min_power to 1.
    */
   void set_max_power(float max_power);
+
+  /** Set the minimum power output of this component.
+   *
+   * All values are multiplied by max_power - min_power and offset by min_power to get the adjusted value.
+   *
+   * @param min_power Automatically clamped from 0 to max_power or 1.
+   */
+  void set_min_power(float min_power);
 
   /// Set the level of this float output, this is called from the front-end.
   void set_level(float state);
@@ -50,6 +59,9 @@ class FloatOutput : public BinaryOutput {
 
   /// Get the maximum power output.
   float get_max_power() const;
+
+  /// Get the minimum power output.
+  float get_min_power() const;
 
   /// Implement BinarySensor's write_enabled; this should never be called.
   void write_state(bool value) override;
@@ -61,6 +73,7 @@ class FloatOutput : public BinaryOutput {
   virtual void write_state(float state) = 0;
 
   float max_power_{1.0f};
+  float min_power_{0.0f};
 };
 
 template<typename T>


### PR DESCRIPTION
## Description:
Adding a min_power configuration to the output component, complementary to the max_power configuration already present. This setting will let the user clamp the output of any floating point variable component like [ESP8266 PWM](https://esphome.io/components/output/esp8266_pwm) to make the full range between min and max available to the frontend in HA. Servos especially will benefit from this, since many standard servos operate in a range between 10%-20% duty cycle.

**Related issue (if applicable):** fixes [feature_requests/#64](https://github.com/esphome/feature-requests/issues/64)

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [X] The code change is tested and works locally.
  - [X] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
