### PR TITLE
Fix feed_wdt

### DIFF
--- a/src/esphome/helpers.cpp
+++ b/src/esphome/helpers.cpp
@@ -388,8 +388,8 @@ void ICACHE_RAM_ATTR HOT feed_wdt() {
 #ifdef ARDUINO_ARCH_ESP32
     yield();
 #endif
+    last_feed = now;
   }
-  last_feed = now;
 }
 std::string build_json(const json_build_t &f) {
   size_t len;


### PR DESCRIPTION
## Description:

Turns out waveshare components can be tested without connecting it, because there's no stuff bein received

Fixes https://github.com/esphome/issues/issues/62

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
