### PR TITLE
HLW8012 don't count a single pulse as power

### DIFF
--- a/src/esphome/sensor/hlw8012.cpp
+++ b/src/esphome/sensor/hlw8012.cpp
@@ -47,8 +47,18 @@ float HLW8012Component::get_setup_priority() const {
   return setup_priority::HARDWARE_LATE;
 }
 void HLW8012Component::update() {
-  float cf_hz = this->cf_.read_raw_value_() / (this->get_update_interval() / 1000.0f);
-  float cf1_hz = this->cf1_.read_raw_value_() / (this->get_update_interval() / 1000.0f);
+  pulse_counter_t raw_cf = this->cf_.read_raw_value_();
+  pulse_counter_t raw_cf1 = this->cf1_.read_raw_value_();
+  float cf_hz = raw_cf / (this->get_update_interval() / 1000.0f);
+  if (raw_cf <= 1) {
+    // don't count single pulse as power
+    cf_hz = 0.0f;
+  }
+  float cf1_hz = raw_cf1 / (this->get_update_interval() / 1000.0f);
+  if (cf1_hz <= 1) {
+    // don't count single pulse as anything
+    cf1_hz = 0.0f;
+  }
 
   if (this->nth_value_++ < 2) {
     return;


### PR DESCRIPTION
## Description:

Single pulses happen on really low power use, but at these levels the sensors are quite inaccurate too. So don't count a single pulse as any power/voltage/etc.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
