### PR TITLE
Set initial brightness to 0 when turning light on

### DIFF
--- a/src/esphome/light/light_transformer.cpp
+++ b/src/esphome/light/light_transformer.cpp
@@ -56,6 +56,7 @@ LightTransitionTransformer::LightTransitionTransformer(uint32_t start_time,
     LightTransformer(start_time, length, start_values, target_values) {
   // When turning light on from off state, use colors from new.
   if (!this->start_values_.is_on() && this->target_values_.is_on()) {
+    this->start_values_.set_brightness(0.0f);
     this->start_values_.set_red(target_values.get_red());
     this->start_values_.set_green(target_values.get_green());
     this->start_values_.set_blue(target_values.get_blue());


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
