### PR TITLE
Add restore state from flash option

### DIFF
--- a/src/esphome/esppreferences.cpp
+++ b/src/esphome/esppreferences.cpp
@@ -5,6 +5,12 @@
 #include "esphome/log.h"
 #include "esphome/helpers.h"
 
+#ifdef USE_ESP8266_PREFERENCES_FLASH
+extern "C" {
+  #include "spi_flash.h"
+}
+#endif
+
 ESPHOME_NAMESPACE_BEGIN
 
 static const char *TAG = "preferences";
@@ -29,7 +35,7 @@ bool ESPPreferenceObject::load_() {
 
   bool valid = this->data_[this->length_words_] == this->calculate_crc_();
 
-  ESP_LOGVV(TAG, "LOAD %u: valid=%s, 0=%u 1=%u (Type=%u, CRC=%u)",
+  ESP_LOGVV(TAG, "LOAD %u: valid=%s, 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)",
             this->rtc_offset_, YESNO(valid), this->data_[0], this->data_[1],
             this->type_, this->calculate_crc_());
   return valid;
@@ -43,7 +49,7 @@ bool ESPPreferenceObject::save_() {
   this->data_[this->length_words_] = this->calculate_crc_();
   if (!this->save_internal_())
     return false;
-  ESP_LOGVV(TAG, "SAVE %u: 0=%u 1=%u (Type=%u, CRC=%u)",
+  ESP_LOGVV(TAG, "SAVE %u: 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)",
             this->rtc_offset_, this->data_[0], this->data_[1],
             this->type_, this->calculate_crc_());
   return true;
@@ -54,6 +60,7 @@ bool ESPPreferenceObject::save_() {
 #define ESP_RTC_USER_MEM_START 0x60001200
 #define ESP_RTC_USER_MEM ((uint32_t *) ESP_RTC_USER_MEM_START)
 #define ESP_RTC_USER_MEM_SIZE_WORDS 128
+#define ESP_RTC_USER_MEM_SIZE_BYTES ESP_RTC_USER_MEM_SIZE_WORDS * 4
 
 static inline bool esp_rtc_user_mem_read(uint32_t index, uint32_t *dest) {
   if (index >= ESP_RTC_USER_MEM_SIZE_WORDS) {
@@ -63,6 +70,10 @@ static inline bool esp_rtc_user_mem_read(uint32_t index, uint32_t *dest) {
   return true;
 }
 
+#ifdef USE_ESP8266_PREFERENCES_FLASH
+static bool esp8266_preferences_modified = false;
+#endif
+
 static inline bool esp_rtc_user_mem_write(uint32_t index, uint32_t value) {
   if (index >= ESP_RTC_USER_MEM_SIZE_WORDS) {
     return false;
@@ -71,15 +82,64 @@ static inline bool esp_rtc_user_mem_write(uint32_t index, uint32_t value) {
     return false;
   }
 
-  ESP_RTC_USER_MEM[index] = value;
+  auto *ptr = &ESP_RTC_USER_MEM[index];
+#ifdef USE_ESP8266_PREFERENCES_FLASH
+  if (*ptr != value) {
+    ESP_LOGV(TAG, "RTC flash is dirty...");
+    esp8266_preferences_modified = true;
+  }
+#endif
+  *ptr = value;
   return true;
 }
+
+#ifdef USE_ESP8266_PREFERENCES_FLASH
+extern "C" uint32_t _SPIFFS_end;
+
+static const uint32_t get_esp8266_flash_sector() {
+  return (uint32_t(&_SPIFFS_end) - 0x40200000) / SPI_FLASH_SEC_SIZE;
+}
+static const uint32_t get_esp8266_flash_address() { return get_esp8266_flash_sector() * SPI_FLASH_SEC_SIZE; }
+
+static void load_esp8266_flash() {
+  ESP_LOGVV(TAG, "Loading preferences from flash...");
+  disable_interrupts();
+  spi_flash_read(get_esp8266_flash_address(), ESP_RTC_USER_MEM, ESP_RTC_USER_MEM_SIZE_BYTES);
+  enable_interrupts();
+}
+static void save_esp8266_flash() {
+  if (!esp8266_preferences_modified)
+    return;
+
+  ESP_LOGVV(TAG, "Saving preferences to flash...");
+  disable_interrupts();
+  auto erase_res = spi_flash_erase_sector(get_esp8266_flash_sector());
+  if (erase_res != SPI_FLASH_RESULT_OK) {
+    enable_interrupts();
+    ESP_LOGV(TAG, "Erase ESP8266 flash failed!");
+    return;
+  }
+
+  auto write_res = spi_flash_write(get_esp8266_flash_address(), ESP_RTC_USER_MEM, ESP_RTC_USER_MEM_SIZE_BYTES);
+  enable_interrupts();
+  if (write_res != SPI_FLASH_RESULT_OK) {
+    ESP_LOGV(TAG, "Write ESP8266 flash failed!");
+    return;
+  }
+
+  esp8266_preferences_modified = false;
+}
+#endif
 
 bool ESPPreferenceObject::save_internal_() {
   for (uint32_t i = 0; i <= this->length_words_; i++) {
     if (!esp_rtc_user_mem_write(this->rtc_offset_ + i, this->data_[i]))
       return false;
   }
+
+#ifdef USE_ESP8266_PREFERENCES_FLASH
+  save_esp8266_flash();
+#endif
   return true;
 }
 bool ESPPreferenceObject::load_internal_() {
@@ -98,7 +158,9 @@ ESPPreferences::ESPPreferences()
 }
 
 void ESPPreferences::begin(const std::string &name) {
-
+#ifdef USE_ESP8266_PREFERENCES_FLASH
+  load_esp8266_flash();
+#endif
 }
 
 ESPPreferenceObject ESPPreferences::make_preference(size_t length, uint32_t type) {


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** Fixes https://github.com/esphome/feature-requests/issues/73

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#459
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#181

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
