### PR TITLE
Add rotary encoder min/max value

### DIFF
--- a/src/esphome/sensor/rotary_encoder.cpp
+++ b/src/esphome/sensor/rotary_encoder.cpp
@@ -122,11 +122,11 @@ void ICACHE_RAM_ATTR RotaryEncoderSensor::process_state_machine_() {
     bool counter_change = false;
 
     if ((this->state_ & QEIx4_IS_INC) != 0) {
-      this->counter_++;
+      this->counter_ = std::min(this->counter_ + 1, this->max_value_);
       counter_change = true;
     }
     if ((this->state_ & QEIx4_IS_DEC) != 0) {
-      this->counter_--;
+      this->counter_ = std::max(this->counter_ - 1, this->min_value_);
       counter_change = true;
     }
 
@@ -164,6 +164,8 @@ std::vector<RotaryEncoderSensor *> global_rotary_encoders_;
 float RotaryEncoderSensor::get_setup_priority() const {
   return setup_priority::HARDWARE_LATE;
 }
+void RotaryEncoderSensor::set_min_value(int32_t min_value) { this->min_value_ = min_value; }
+void RotaryEncoderSensor::set_max_value(int32_t max_value) { this->max_value_ = max_value; }
 
 } // namespace sensor
 

--- a/src/esphome/sensor/rotary_encoder.h
+++ b/src/esphome/sensor/rotary_encoder.h
@@ -35,6 +35,8 @@ class RotaryEncoderSensor : public Sensor, public Component {
   void set_resolution(RotaryEncoderResolution mode);
 
   void set_reset_pin(const GPIOInputPin &pin_i);
+  void set_min_value(int32_t min_value);
+  void set_max_value(int32_t max_value);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -62,6 +64,8 @@ class RotaryEncoderSensor : public Sensor, public Component {
   volatile bool has_changed_{true};
   uint16_t state_{0};
   RotaryEncoderResolution resolution_{ROTARY_ENCODER_1_PULSE_PER_CYCLE};
+  int32_t min_value_{INT32_MIN};
+  int32_t max_value_{INT32_MAX};
 };
 
 /// Global storage for having multiple rotary encoders with a single ISR


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
