### PR TITLE
SDS011: change type of update_interval_min to uint8_t

### DIFF
--- a/src/esphome/sensor/sds011_component.cpp
+++ b/src/esphome/sensor/sds011_component.cpp
@@ -35,7 +35,7 @@ static const uint8_t SDS011_MODE_REPORT_QUERY = 0x01;
 static const uint8_t SDS011_MODE_SLEEP = 0x00;
 static const uint8_t SDS011_MODE_WORK = 0x01;
 
-SDS011Component::SDS011Component(UARTComponent *parent, uint32_t update_interval_min, bool rx_mode_only)
+SDS011Component::SDS011Component(UARTComponent *parent, uint8_t update_interval_min, bool rx_mode_only)
     : UARTDevice(parent), update_interval_min_(update_interval_min), rx_mode_only_(rx_mode_only) {}
 
 void SDS011Component::setup() {
@@ -187,7 +187,7 @@ void SDS011Component::parse_data_() {
 uint16_t SDS011Component::get_16_bit_uint_(uint8_t start_index) const {
   return (uint16_t(this->data_[start_index + 1]) << 8) | uint16_t(this->data_[start_index]);
 }
-void SDS011Component::set_update_interval_min(uint32_t update_interval_min) {
+void SDS011Component::set_update_interval_min(uint8_t update_interval_min) {
   this->update_interval_min_ = update_interval_min;
 }
 

--- a/src/esphome/sensor/sds011_component.h
+++ b/src/esphome/sensor/sds011_component.h
@@ -23,7 +23,7 @@ class SDS011Component : public Component, public UARTDevice {
    * @param update_interval_min The update interval in minutes.
    * @param rx_mode_only RX-only mode to avoid sending data to the sensor.
    */
-  SDS011Component(UARTComponent *parent, uint32_t update_interval_min = 0, bool rx_mode_only = false);
+  SDS011Component(UARTComponent *parent, uint8_t update_interval_min = 0, bool rx_mode_only = false);
 
   /// Manually set the rx-only mode. Defaults to false.
   void set_rx_mode_only(bool rx_mode_only);
@@ -39,7 +39,7 @@ class SDS011Component : public Component, public UARTDevice {
   SDS011Sensor *make_pm_10_0_sensor(const std::string &name);
   bool get_rx_mode_only() const;
 
-  void set_update_interval_min(uint32_t update_interval_min);
+  void set_update_interval_min(uint8_t update_interval_min);
 
  protected:
   void sds011_write_command_(const uint8_t *command);
@@ -54,7 +54,7 @@ class SDS011Component : public Component, public UARTDevice {
   uint8_t data_[10];
   uint8_t data_index_{0};
   uint32_t last_transmission_{0};
-  uint32_t update_interval_min_;
+  uint8_t update_interval_min_;
 
   bool rx_mode_only_;
 };


### PR DESCRIPTION
## Description:

The value of `update_interval_min` is used as it is as a byte for the UART message. To avoid type casting, it is better to define it as `uint8_t`.

**Related issue (if applicable):** fixes #538 

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
