### PR TITLE
Fixed: Waveshare 4.2in display timing problem due to high speed SPI u…

### DIFF
--- a/src/esphome/display/waveshare_epaper.cpp
+++ b/src/esphome/display/waveshare_epaper.cpp
@@ -530,6 +530,7 @@ void HOT WaveshareEPaper4P2In::display() {
 }
 int WaveshareEPaper4P2In::get_width_internal() { return 400; }
 int WaveshareEPaper4P2In::get_height_internal() { return 300; }
+bool WaveshareEPaper4P2In::is_device_high_speed() { return false; }
 WaveshareEPaper4P2In::WaveshareEPaper4P2In(SPIComponent *parent, GPIOPin *cs, GPIOPin *dc_pin, uint32_t update_interval)
     : WaveshareEPaper(parent, cs, dc_pin, update_interval) {}
 void WaveshareEPaper4P2In::dump_config() {

--- a/src/esphome/display/waveshare_epaper.h
+++ b/src/esphome/display/waveshare_epaper.h
@@ -115,6 +115,8 @@ class WaveshareEPaper4P2In : public WaveshareEPaper {
   int get_width_internal() override;
 
   int get_height_internal() override;
+
+  bool is_device_high_speed() override;
 };
 
 class WaveshareEPaper7P5In : public WaveshareEPaper {


### PR DESCRIPTION

## Description:
Changed Waveshare epaper driver for 4.2 inch display to use low speed SPI only.

**Related issue (if applicable):** fixes (see discussion on Discord on March 4th/5th)

## Checklist:

  - [X] The code change is tested and works locally.
  - [X] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

No change in documentation needed for this fix.