### PR TITLE
More changes for 1.12

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ platform = espressif8266@1.8.0
 board = nodemcuv2
 framework = arduino
 lib_deps = ${common.lib_deps}
-build_flags = ${common.build_flags}
+build_flags = ${common.build_flags} -DESPHOME_LOG_LEVEL=6
 src_filter = ${common.src_filter} +<examples/livingroom8266/livingroom8266.cpp>
 
 [env:custombmp180]

--- a/src/esphome/api/api_server.cpp
+++ b/src/esphome/api/api_server.cpp
@@ -714,6 +714,12 @@ bool APIConnection::send_buffer(APIMessageType type) {
 }
 
 void APIConnection::loop() {
+  if (!network_is_connected()) {
+    // when network is disconnected force disconnect immediately
+    // don't wait for timeout
+    this->fatal_error_();
+    return;
+  }
   if (this->client_->disconnected()) {
     // failsafe for disconnect logic
     this->on_disconnect_();

--- a/src/esphome/api/api_server.cpp
+++ b/src/esphome/api/api_server.cpp
@@ -90,8 +90,10 @@ void APIServer::loop() {
         ESP_LOGE(TAG, "No client connected to API. Rebooting...");
         reboot("api");
       }
+      this->status_set_warning();
     } else {
       this->last_connected_ = now;
+      this->status_clear_warning();
     }
   }
 }

--- a/src/esphome/application.h
+++ b/src/esphome/application.h
@@ -334,7 +334,9 @@ class Application {
   template<typename T> GlobalVariableComponent<T> *make_global_variable();
 
   template<typename T> GlobalVariableComponent<T> *make_global_variable(T initial_value);
-  template<typename T> GlobalVariableComponent<T> *make_global_variable(std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value);
+  template<typename T>
+  GlobalVariableComponent<T> *make_global_variable(
+      std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value);
 
   /*           _    _ _______ ____  __  __       _______ _____ ____  _   _
    *      /\  | |  | |__   __/ __ \|  \/  |   /\|__   __|_   _/ __ \| \ | |
@@ -1235,7 +1237,8 @@ template<typename T> GlobalVariableComponent<T> *Application::make_global_variab
   return this->register_component(new GlobalVariableComponent<T>(initial_value));
 }
 template<typename T>
-GlobalVariableComponent<T> *Application::make_global_variable(std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value) {
+GlobalVariableComponent<T> *Application::make_global_variable(
+    std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value) {
   return this->register_component(new GlobalVariableComponent<T>(initial_value));
 }
 

--- a/src/esphome/application.h
+++ b/src/esphome/application.h
@@ -334,6 +334,7 @@ class Application {
   template<typename T> GlobalVariableComponent<T> *make_global_variable();
 
   template<typename T> GlobalVariableComponent<T> *make_global_variable(T initial_value);
+  template<typename T> GlobalVariableComponent<T> *make_global_variable(std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value);
 
   /*           _    _ _______ ____  __  __       _______ _____ ____  _   _
    *      /\  | |  | |__   __/ __ \|  \/  |   /\|__   __|_   _/ __ \| \ | |
@@ -1231,6 +1232,10 @@ template<typename T> GlobalVariableComponent<T> *Application::make_global_variab
 }
 
 template<typename T> GlobalVariableComponent<T> *Application::make_global_variable(T initial_value) {
+  return this->register_component(new GlobalVariableComponent<T>(initial_value));
+}
+template<typename T>
+GlobalVariableComponent<T> *Application::make_global_variable(std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value) {
   return this->register_component(new GlobalVariableComponent<T>(initial_value));
 }
 

--- a/src/esphome/automation.h
+++ b/src/esphome/automation.h
@@ -276,7 +276,8 @@ template<typename T> class GlobalVariableComponent : public Component {
  public:
   explicit GlobalVariableComponent();
   explicit GlobalVariableComponent(T initial_value);
-  explicit GlobalVariableComponent(std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value);
+  explicit GlobalVariableComponent(
+      std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value);
 
   T &value();
 

--- a/src/esphome/automation.h
+++ b/src/esphome/automation.h
@@ -276,6 +276,7 @@ template<typename T> class GlobalVariableComponent : public Component {
  public:
   explicit GlobalVariableComponent();
   explicit GlobalVariableComponent(T initial_value);
+  explicit GlobalVariableComponent(std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value);
 
   T &value();
 

--- a/src/esphome/automation.tcc
+++ b/src/esphome/automation.tcc
@@ -208,7 +208,8 @@ template<typename... Ts> ScriptStopAction<Ts...> *Script::make_stop_action() {
 template<typename T> GlobalVariableComponent<T>::GlobalVariableComponent() {}
 template<typename T> GlobalVariableComponent<T>::GlobalVariableComponent(T initial_value) : value_(initial_value) {}
 template<typename T>
-GlobalVariableComponent<T>::GlobalVariableComponent(std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value) {
+GlobalVariableComponent<T>::GlobalVariableComponent(
+    std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value) {
   memcpy(this->value_, initial_value.data(), sizeof(T));
 }
 template<typename T> T &GlobalVariableComponent<T>::value() { return this->value_; }

--- a/src/esphome/automation.tcc
+++ b/src/esphome/automation.tcc
@@ -207,6 +207,10 @@ template<typename... Ts> ScriptStopAction<Ts...> *Script::make_stop_action() {
 
 template<typename T> GlobalVariableComponent<T>::GlobalVariableComponent() {}
 template<typename T> GlobalVariableComponent<T>::GlobalVariableComponent(T initial_value) : value_(initial_value) {}
+template<typename T>
+GlobalVariableComponent<T>::GlobalVariableComponent(std::array<typename std::remove_extent<T>::type, std::extent<T>::value> initial_value) {
+  memcpy(this->value_, initial_value.data(), sizeof(T));
+}
 template<typename T> T &GlobalVariableComponent<T>::value() { return this->value_; }
 template<typename T> void GlobalVariableComponent<T>::setup() {
   if (this->restore_value_) {

--- a/src/esphome/binary_sensor/binary_sensor.cpp
+++ b/src/esphome/binary_sensor/binary_sensor.cpp
@@ -194,15 +194,15 @@ void MultiClickTrigger::on_state_(bool state) {
   MultiClickTriggerEvent evt = this->timing_[*this->at_index_];
 
   if (evt.max_length != 4294967294UL) {
-    ESP_LOGV(TAG, "A i=%u min=%u max=%u", *this->at_index_, evt.min_length, evt.max_length);
+    ESP_LOGV(TAG, "A i=%lu min=%u max=%u", *this->at_index_, evt.min_length, evt.max_length);
     this->schedule_is_valid_(evt.min_length);
     this->schedule_is_not_valid_(evt.max_length);
   } else if (*this->at_index_ + 1 != this->timing_.size()) {
-    ESP_LOGV(TAG, "B i=%u min=%u", *this->at_index_, evt.min_length);
+    ESP_LOGV(TAG, "B i=%lu min=%u", *this->at_index_, evt.min_length);
     this->cancel_timeout("is_not_valid");
     this->schedule_is_valid_(evt.min_length);
   } else {
-    ESP_LOGV(TAG, "C i=%u min=%u", *this->at_index_, evt.min_length);
+    ESP_LOGV(TAG, "C i=%lu min=%u", *this->at_index_, evt.min_length);
     this->is_valid_ = false;
     this->cancel_timeout("is_not_valid");
     this->set_timeout("trigger", evt.min_length, [this]() { this->trigger_(); });

--- a/src/esphome/binary_sensor/binary_sensor.cpp
+++ b/src/esphome/binary_sensor/binary_sensor.cpp
@@ -194,15 +194,15 @@ void MultiClickTrigger::on_state_(bool state) {
   MultiClickTriggerEvent evt = this->timing_[*this->at_index_];
 
   if (evt.max_length != 4294967294UL) {
-    ESP_LOGV(TAG, "A i=%lu min=%u max=%u", *this->at_index_, evt.min_length, evt.max_length);
+    ESP_LOGV(TAG, "A i=%u min=%u max=%u", *this->at_index_, evt.min_length, evt.max_length);  // NOLINT
     this->schedule_is_valid_(evt.min_length);
     this->schedule_is_not_valid_(evt.max_length);
   } else if (*this->at_index_ + 1 != this->timing_.size()) {
-    ESP_LOGV(TAG, "B i=%lu min=%u", *this->at_index_, evt.min_length);
+    ESP_LOGV(TAG, "B i=%u min=%u", *this->at_index_, evt.min_length);  // NOLINT
     this->cancel_timeout("is_not_valid");
     this->schedule_is_valid_(evt.min_length);
   } else {
-    ESP_LOGV(TAG, "C i=%lu min=%u", *this->at_index_, evt.min_length);
+    ESP_LOGV(TAG, "C i=%u min=%u", *this->at_index_, evt.min_length);  // NOLINT
     this->is_valid_ = false;
     this->cancel_timeout("is_not_valid");
     this->set_timeout("trigger", evt.min_length, [this]() { this->trigger_(); });

--- a/src/esphome/esppreferences.cpp
+++ b/src/esphome/esppreferences.cpp
@@ -80,7 +80,6 @@ static inline bool esp_rtc_user_mem_write(uint32_t index, uint32_t value) {
   auto *ptr = &ESP_RTC_USER_MEM[index];
 #ifdef USE_ESP8266_PREFERENCES_FLASH
   if (*ptr != value) {
-    ESP_LOGV(TAG, "RTC flash is dirty...");
     esp8266_preferences_modified = true;
   }
 #endif

--- a/src/esphome/esppreferences.cpp
+++ b/src/esphome/esppreferences.cpp
@@ -32,7 +32,7 @@ bool ESPPreferenceObject::load_() {
 
   bool valid = this->data_[this->length_words_] == this->calculate_crc_();
 
-  ESP_LOGVV(TAG, "LOAD %u: valid=%s, 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)", this->rtc_offset_, YESNO(valid),
+  ESP_LOGVV(TAG, "LOAD %zu: valid=%s, 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)", this->rtc_offset_, YESNO(valid),
             this->data_[0], this->data_[1], this->type_, this->calculate_crc_());
   return valid;
 }
@@ -45,7 +45,7 @@ bool ESPPreferenceObject::save_() {
   this->data_[this->length_words_] = this->calculate_crc_();
   if (!this->save_internal_())
     return false;
-  ESP_LOGVV(TAG, "SAVE %u: 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)", this->rtc_offset_, this->data_[0], this->data_[1],
+  ESP_LOGVV(TAG, "SAVE %zu: 0=0x%08X 1=0x%08X (Type=%u, CRC=0x%08X)", this->rtc_offset_, this->data_[0], this->data_[1],
             this->type_, this->calculate_crc_());
   return true;
 }

--- a/src/esphome/light/light_color_values.cpp
+++ b/src/esphome/light/light_color_values.cpp
@@ -82,18 +82,33 @@ void LightColorValues::normalize_color(const LightTraits &traits) {
     float max_value = fmaxf(this->get_red(), fmaxf(this->get_green(), this->get_blue()));
     if (traits.has_rgb_white_value()) {
       max_value = fmaxf(max_value, this->get_white());
-      this->set_white(this->get_white() / max_value);
+      if (max_value == 0.0f) {
+        this->set_white(1.0f);
+      } else {
+        this->set_white(this->get_white() / max_value);
+      }
     }
-    this->set_red(this->get_red() / max_value);
-    this->set_green(this->get_green() / max_value);
-    this->set_blue(this->get_blue() / max_value);
+    if (max_value == 0.0f) {
+      this->set_red(1.0f);
+      this->set_green(1.0f);
+      this->set_blue(1.0f);
+    } else {
+      this->set_red(this->get_red() / max_value);
+      this->set_green(this->get_green() / max_value);
+      this->set_blue(this->get_blue() / max_value);
+    }
   }
 
   if (traits.has_brightness() && this->get_brightness() == 0.0f) {
-    // 0% brightness means off
-    this->set_state(false);
-    // reset brightness to 100% (0% brightness is not allowed)
-    this->set_brightness(1.0f);
+    if (traits.has_rgb_white_value()) {
+      // 0% brightness for RGBW[W] means no RGB channel, but white channel on.
+      // do nothing
+    } else {
+      // 0% brightness means off
+      this->set_state(false);
+      // reset brightness to 100%
+      this->set_brightness(1.0f);
+    }
   }
 }
 

--- a/src/esphome/light/light_state.cpp
+++ b/src/esphome/light/light_state.cpp
@@ -438,7 +438,7 @@ void LightState::StateCall::perform() const {
     ESP_LOGD(TAG, "  Color Temperature: %.1f mireds", v.get_color_temperature());
   }
 
-  v.normalize_color(this->state_->output_->get_traits());
+  v.normalize_color(traits);
 
   if (traits.has_rgb() && (this->red_.has_value() || this->green_.has_value() || this->blue_.has_value())) {
     if (traits.has_rgb_white_value() && this->white_.has_value()) {

--- a/src/esphome/light/light_state.cpp
+++ b/src/esphome/light/light_state.cpp
@@ -124,14 +124,14 @@ void LightState::dump_json(JsonObject &root) {
 }
 
 struct LightStateRTCState {
-  bool state;
-  float brightness;
-  float red;
-  float green;
-  float blue;
-  float white;
-  float color_temp;
-  uint32_t effect;
+  bool state{false};
+  float brightness{1.0f};
+  float red{1.0f};
+  float green{1.0f};
+  float blue{1.0f};
+  float white{1.0f};
+  float color_temp{1.0f};
+  uint32_t effect{0};
 };
 
 void LightState::setup() {
@@ -143,9 +143,9 @@ void LightState::setup() {
   }
 
   this->rtc_ = global_preferences.make_preference<LightStateRTCState>(this->get_object_id_hash());
-  LightStateRTCState recovered;
-  if (!this->rtc_.load(&recovered))
-    return;
+  LightStateRTCState recovered{};
+  // Attempt to load from preferences, else fall back to default values from struct
+  this->rtc_.load(&recovered);
 
   auto call = this->make_call();
   call.set_state(recovered.state);

--- a/src/esphome/remote/remote_receiver.cpp
+++ b/src/esphome/remote/remote_receiver.cpp
@@ -326,8 +326,8 @@ void RemoteReceiverComponent::loop() {
     // TODO: Handle case when loop() is not called quickly enough to catch idle
     return;
 
-  ESP_LOGVV(TAG, "read_at=%u write_at=%u dist=%u now=%u end=%u", this->buffer_read_at_, write_at, dist, now,
-            this->buffer_[write_at]);
+  ESP_LOGVV(TAG, "read_at=%u write_at=%u dist=%u now=%u end=%u", s.buffer_read_at, write_at, dist, now,
+            s.buffer[write_at]);
 
   // Skip first value, it's from the previous idle level
   s.buffer_read_at = (s.buffer_read_at + 1) % s.buffer_size;
@@ -345,8 +345,8 @@ void RemoteReceiverComponent::loop() {
       break;
     }
 
-    ESP_LOGVV(TAG, "  i=%u buffer[%u]=%u - buffer[%u]=%u -> %d", i, this->buffer_read_at_,
-              this->buffer_[this->buffer_read_at_], prev, this->buffer_[prev], multiplier * delta);
+    ESP_LOGVV(TAG, "  i=%u buffer[%u]=%u - buffer[%u]=%u -> %d", i, s.buffer_read_at,
+              s.buffer[s.buffer_read_at], prev, s.buffer[prev], multiplier * delta);
     this->temp_.push_back(multiplier * delta);
     prev = s.buffer_read_at;
     s.buffer_read_at = (s.buffer_read_at + 1) % s.buffer_size;

--- a/src/esphome/remote/remote_receiver.cpp
+++ b/src/esphome/remote/remote_receiver.cpp
@@ -345,8 +345,8 @@ void RemoteReceiverComponent::loop() {
       break;
     }
 
-    ESP_LOGVV(TAG, "  i=%u buffer[%u]=%u - buffer[%u]=%u -> %d", i, s.buffer_read_at,
-              s.buffer[s.buffer_read_at], prev, s.buffer[prev], multiplier * delta);
+    ESP_LOGVV(TAG, "  i=%u buffer[%u]=%u - buffer[%u]=%u -> %d", i, s.buffer_read_at, s.buffer[s.buffer_read_at], prev,
+              s.buffer[prev], multiplier * delta);
     this->temp_.push_back(multiplier * delta);
     prev = s.buffer_read_at;
     s.buffer_read_at = (s.buffer_read_at + 1) % s.buffer_size;

--- a/src/esphome/sensor/rotary_encoder.cpp
+++ b/src/esphome/sensor/rotary_encoder.cpp
@@ -88,7 +88,7 @@ void ICACHE_RAM_ATTR HOT RotaryEncoderSensorStore::gpio_intr(RotaryEncoderSensor
   if (arg->pin_b->digital_read())
     input_state |= STATE_PIN_B_HIGH;
 
-  uint8_t new_state = STATE_LOOKUP_TABLE[input_state];
+  uint16_t new_state = STATE_LOOKUP_TABLE[input_state];
   if ((new_state & arg->resolution & STATE_HAS_INCREMENTED) != 0) {
     if (arg->counter < arg->max_value)
       arg->counter++;


### PR DESCRIPTION
## Description:

- Enable very verbose mode for clang checks
- Set warning if no client is connected to native API
- Close native API connection immediately if network connection is lost
- Prevent some sporadic reboots on ESP8266 when reconnecting to network.
- Fixes https://github.com/esphome/issues/issues/131
- Fixes https://github.com/esphome/issues/issues/124
- Fixes https://github.com/esphome/issues/issues/117

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
