### PR TITLE
Fix homeassistant mqtt discovery for light components

### DIFF
--- a/src/esphome/light/mqtt_json_light_component.cpp
+++ b/src/esphome/light/mqtt_json_light_component.cpp
@@ -31,6 +31,7 @@ bool MQTTJSONLightComponent::publish_state_() {
 LightState *MQTTJSONLightComponent::get_state() const { return this->state_; }
 std::string MQTTJSONLightComponent::friendly_name() const { return this->state_->get_name(); }
 void MQTTJSONLightComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig &config) {
+  root["schema"] = "json";
   if (this->state_->get_traits().has_brightness())
     root["brightness"] = true;
   if (this->state_->get_traits().has_rgb())


### PR DESCRIPTION
## Description:

Seems to be a regression introduced with #535. HA light.mqtt require `schema: json` otherwise it will not send json.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
