### PR TITLE
Revert ultrasonic sensor to non-interrupt mode

### DIFF
--- a/src/esphome/application.h
+++ b/src/esphome/application.h
@@ -570,12 +570,12 @@ class Application {
    * @param friendly_name The friendly name for this sensor advertised to Home Assistant.
    * @param trigger_pin The pin the short pulse will be sent to, can be integer or GPIOOutputPin.
    * @param echo_pin The pin we wait that we wait on for the echo, can be integer or GPIOInputPin.
-   * @param update_interval The time in ms between updates, defaults to 5 seconds.
+   * @param update_interval The time in ms between updates, defaults to 60 seconds.
    */
   sensor::UltrasonicSensorComponent *make_ultrasonic_sensor(const std::string &friendly_name,
                                                             const GPIOOutputPin &trigger_pin,
                                                             const GPIOInputPin &echo_pin,
-                                                            uint32_t update_interval = 5000);
+                                                            uint32_t update_interval = 60000);
 #endif
 
 #ifdef USE_WIFI_SIGNAL_SENSOR

--- a/src/esphome/sensor/ultrasonic_sensor.cpp
+++ b/src/esphome/sensor/ultrasonic_sensor.cpp
@@ -35,7 +35,7 @@ void UltrasonicSensorComponent::update() {
     ESP_LOGV(TAG, "Distance measurement timed out!");
     this->publish_state(NAN);
   } else {
-    float result = this->us_to_m(time);
+    float result = UltrasonicSensorComponent::us_to_m(time);
     this->publish_state(result);
     ESP_LOGD(TAG, "Got distance: %.2f m", result);
     this->publish_state(result);

--- a/src/esphome/sensor/ultrasonic_sensor.cpp
+++ b/src/esphome/sensor/ultrasonic_sensor.cpp
@@ -32,12 +32,12 @@ void UltrasonicSensorComponent::update() {
   ESP_LOGV(TAG, "Echo took %uµs", time);
 
   if (time == 0) {
-    ESP_LOGV(TAG, "Distance measurement timed out!");
+    ESP_LOGD(TAG, "'%s' - Distance measurement timed out!", this->name_.c_str());
     this->publish_state(NAN);
   } else {
     float result = UltrasonicSensorComponent::us_to_m(time);
     this->publish_state(result);
-    ESP_LOGD(TAG, "Got distance: %.2f m", result);
+    ESP_LOGD(TAG, "'%s' - Got distance: %.2f m", this->name_.c_str(), result);
     this->publish_state(result);
   }
 }

--- a/src/esphome/sensor/ultrasonic_sensor.h
+++ b/src/esphome/sensor/ultrasonic_sensor.h
@@ -12,15 +12,6 @@ ESPHOME_NAMESPACE_BEGIN
 
 namespace sensor {
 
-struct UltrasonicSensorStore {
-  uint32_t triggered_at{0};
-  bool has_triggered{false};
-  uint32_t echo_at{0};
-  bool has_echo{false};
-
-  static void gpio_intr(UltrasonicSensorStore *arg);
-};
-
 class UltrasonicSensorComponent : public PollingSensorComponent {
  public:
   /** Construct the ultrasonic sensor with the specified trigger pin and echo pin.
@@ -42,7 +33,6 @@ class UltrasonicSensorComponent : public PollingSensorComponent {
   void dump_config() override;
 
   void update() override;
-  void loop() override;
 
   std::string unit_of_measurement() override;
   std::string icon() override;
@@ -60,9 +50,8 @@ class UltrasonicSensorComponent : public PollingSensorComponent {
 
   GPIOPin *trigger_pin_;
   GPIOPin *echo_pin_;
-  uint32_t timeout_us_{58309};  /// 10 meters.
+  uint32_t timeout_us_{11662};  /// 2 meters.
   uint32_t pulse_time_us_{10};
-  UltrasonicSensorStore store_{};
 };
 
 }  // namespace sensor

--- a/src/esphome/sensor/ultrasonic_sensor.h
+++ b/src/esphome/sensor/ultrasonic_sensor.h
@@ -12,9 +12,6 @@ ESPHOME_NAMESPACE_BEGIN
 
 namespace sensor {
 
-/// The speed of sound in air in meters per µs.
-const float SPEED_OF_SOUND_M_PER_US = 0.000343f;
-
 struct UltrasonicSensorStore {
   uint32_t triggered_at{0};
   bool has_triggered{false};
@@ -65,7 +62,7 @@ class UltrasonicSensorComponent : public PollingSensorComponent {
   GPIOPin *echo_pin_;
   uint32_t timeout_us_{58309};  /// 10 meters.
   uint32_t pulse_time_us_{10};
-  UltrasonicSensorStore store_;
+  UltrasonicSensorStore store_{};
 };
 
 }  // namespace sensor


### PR DESCRIPTION
## Description:

The ultrasonic sensors must be generating a short pulse on the echo pin when trigger is pulsed. No good way to fix that with interrupt mode.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/147

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
