### PR TITLE
ESP8266 SDK Core 2.3.0 compat

### DIFF
--- a/src/esphome/defines.h
+++ b/src/esphome/defines.h
@@ -1,6 +1,10 @@
 #ifndef ESPHOME_DEFINES_H
 #define ESPHOME_DEFINES_H
 
+#ifdef ARDUINO_ARCH_ESP8266
+#include <core_version.h>
+#endif
+
 #define ESPHOME_VERSION "1.13.0-dev"
 
 #define HOT __attribute__((hot))
@@ -42,7 +46,9 @@
 #define USE_PCA9685_OUTPUT
 #define USE_GPIO_OUTPUT
 #ifdef ARDUINO_ARCH_ESP8266
+#ifndef ARDUINO_ESP8266_RELEASE_2_3_0
 #define USE_ESP8266_PWM_OUTPUT
+#endif
 #endif
 #define USE_LIGHT
 #define USE_SWITCH

--- a/src/esphome/esphal.cpp
+++ b/src/esphome/esphal.cpp
@@ -266,3 +266,19 @@ ISRInternalGPIOPin *GPIOPin::to_isr() const {
 }
 
 ESPHOME_NAMESPACE_END
+
+#ifdef ARDUINO_ESP8266_RELEASE_2_3_0
+// Fix 2.3.0 std missing memchr
+extern "C" {
+void *memchr(const void *s, int c, size_t n) {
+  if (n == 0)
+    return nullptr;
+  const uint8_t *p = reinterpret_cast<const uint8_t *>(s);
+  do {
+    if (*p++ == c)
+      return const_cast<void *>(reinterpret_cast<const void *>(p - 1));
+  } while (--n != 0);
+  return nullptr;
+}
+};
+#endif

--- a/src/esphome/light/neo_pixel_bus_light_output.h
+++ b/src/esphome/light/neo_pixel_bus_light_output.h
@@ -5,6 +5,10 @@
 
 #ifdef USE_NEO_PIXEL_BUS_LIGHT
 
+#ifdef ARDUINO_ESP8266_RELEASE_2_3_0
+#error The NeoPixelBus library requires at least arduino_core_version 2.4.x
+#endif
+
 #include "esphome/helpers.h"
 #include "esphome/light/light_state.h"
 #include "esphome/light/addressable_light.h"

--- a/src/esphome/ota_component.cpp
+++ b/src/esphome/ota_component.cpp
@@ -220,7 +220,7 @@ void OTAComponent::handle_() {
     ESP_LOGV(TAG, "Auth: Nonce is %s", sbuf);
 
     // Send nonce, 32 bytes hex MD5
-    if (this->client_.write(reinterpret_cast<uint8_t*>(sbuf), 32) != 32) {
+    if (this->client_.write(reinterpret_cast<uint8_t *>(sbuf), 32) != 32) {
       ESP_LOGW(TAG, "Auth: Writing nonce failed!");
       goto error;
     }

--- a/src/esphome/ota_component.cpp
+++ b/src/esphome/ota_component.cpp
@@ -220,7 +220,7 @@ void OTAComponent::handle_() {
     ESP_LOGV(TAG, "Auth: Nonce is %s", sbuf);
 
     // Send nonce, 32 bytes hex MD5
-    if (this->client_.write(sbuf, 32) != 32) {
+    if (this->client_.write(reinterpret_cast<uint8_t*>(sbuf), 32) != 32) {
       ESP_LOGW(TAG, "Auth: Writing nonce failed!");
       goto error;
     }
@@ -386,7 +386,7 @@ error:
     ESP_LOGW(TAG, "Update end failed! Error: %s", ss.c_str());
   }
   if (this->client_.connected()) {
-    this->client_.write(error_code);
+    this->client_.write(static_cast<uint8_t>(error_code));
     this->client_.flush();
   }
   this->client_.stop();

--- a/src/esphome/output/esp8266_pwm_output.cpp
+++ b/src/esphome/output/esp8266_pwm_output.cpp
@@ -2,6 +2,10 @@
 
 #ifdef USE_ESP8266_PWM_OUTPUT
 
+#ifdef ARDUINO_ESP8266_RELEASE_2_3_0
+#error ESP8266 PWM requires at least arduino_core_version 2.4.0
+#endif
+
 #include "esphome/output/esp8266_pwm_output.h"
 #include "esphome/espmath.h"
 #include "esphome/log.h"

--- a/src/esphome/wifi_component.h
+++ b/src/esphome/wifi_component.h
@@ -2,6 +2,7 @@
 #define ESPHOME_WIFI_COMPONENT_H
 
 #include <string>
+#include "esphal.h"
 #include <IPAddress.h>
 
 #ifdef ARDUINO_ARCH_ESP32
@@ -12,6 +13,11 @@
 #ifdef ARDUINO_ARCH_ESP8266
 #include <ESP8266WiFiType.h>
 #include <ESP8266WiFi.h>
+#ifdef ARDUINO_ESP8266_RELEASE_2_3_0
+extern "C" {
+#include <user_interface.h>
+};
+#endif
 #endif
 
 #include "esphome/automation.h"


### PR DESCRIPTION
## Description:

Adds basic support for core SDK core 2.3.0 for ESP8266. Some components will likely give compile errors, but I certainly won't backport them (huge pain).

These things won' work:

- everything that uses pin interrupts (uart, pulse counter, duty cycle, rotary encoder, remote receiver)
- neopixelbus
- PWM

Expect other things to break too, I don't consider 2.3.0 officially supported.

**Related issue (if applicable):** fixes https://github.com/esphome/issues/issues/145

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
