### PR TITLE
Fix ESP8266 cannot OTA after failed OTA attempt

### DIFF
--- a/src/esphome/ota_component.cpp
+++ b/src/esphome/ota_component.cpp
@@ -395,6 +395,11 @@ error:
     Update.abort();
   }
 #endif
+#ifdef ARDUINO_ARCH_ESP8266
+  if (update_started) {
+    Update.end();
+  }
+#endif
   this->status_momentary_error("onerror", 5000);
 #ifdef ARDUINO_ARCH_ESP8266
   global_preferences.prevent_write(false);


### PR DESCRIPTION
fixes https://github.com/esphome/issues/issues/114

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
