### PR TITLE
Disable wifi interface on shutdown

### DIFF
--- a/src/esphome/wifi_component.cpp
+++ b/src/esphome/wifi_component.cpp
@@ -52,6 +52,11 @@ void WiFiComponent::setup() {
 
   this->wifi_apply_hostname_();
   network_setup_mdns();
+
+  add_shutdown_hook([this](const char *reason) {
+    // Disable WiFi interface on shutdown
+    this->wifi_mode_(false, false);
+  });
 }
 
 void WiFiComponent::loop() {


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/149

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
