### PR TITLE
WIP Adding position and tilt to template cover

### DIFF
--- a/src/esphome/cover/cover.cpp
+++ b/src/esphome/cover/cover.cpp
@@ -19,12 +19,51 @@ void Cover::publish_state(CoverState state) {
   this->state = state;
   this->state_callback_.call(state);
 }
+void Cover::add_on_publish_position_callback(std::function<void(position_value_t)> &&p) {
+  this->position_callback_.add(std::move(p));
+}
+void Cover::publish_position(position_value_t position_value) {
+  this->position_value = position_value;
+  this->position_callback_.call(position_value);
+}
+void Cover::add_on_publish_tilt_callback(std::function<void(tilt_value_t)> &&t) {
+  this->tilt_callback_.add(std::move(t));
+}
+void Cover::publish_tilt(tilt_value_t tilt_value) {
+  this->tilt_value = tilt_value;
+  this->tilt_callback_.call(tilt_value);
+}
 bool Cover::assumed_state() { return false; }
+void Cover::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
+bool Cover::optimistic() {return this->optimistic_; }
 bool Cover::has_state() const { return this->dedup_.has_value(); }
+void Cover::set_position_open(float position_open) { this->position_open_ = position_open; }
+float Cover::position_open() { return this->position_open_; }
+void Cover::set_position_closed(float position_closed) { this->position_closed_ = position_closed; }
+float Cover::position_closed() { return this->position_closed_; }
+void Cover::set_tilt_min(float tilt_min) { this->tilt_min_ = tilt_min; }
+float Cover::tilt_min() { return this->tilt_min_; }
+void Cover::set_tilt_max(float tilt_max) { this->tilt_max_ = tilt_max; }
+float Cover::tilt_max() { return this->tilt_max_; }
+void Cover::set_tilt_closed_value(float tilt_closed_value) { this->tilt_closed_value_ = tilt_closed_value; }
+float Cover::tilt_closed_value() { return this->tilt_closed_value_; }
+void Cover::set_tilt_opened_value(float tilt_opened_value) { this->tilt_opened_value_ = tilt_opened_value; }
+float Cover::tilt_opened_value() { return this->tilt_opened_value_; }
+void Cover::set_tilt_invert_state(bool tilt_invert_state) { this->tilt_invert_state_ = tilt_invert_state; }
+bool Cover::tilt_invert_state() { return this->tilt_invert_state_; }
 
 void Cover::open() { this->write_command(COVER_COMMAND_OPEN); }
 void Cover::close() { this->write_command(COVER_COMMAND_CLOSE); }
 void Cover::stop() { this->write_command(COVER_COMMAND_STOP); }
+
+void Cover::set_position(float value) {
+  this->position_value = value;
+  this->write_command(COVER_COMMAND_POSITION, value);
+}
+void Cover::set_tilt(float value) {
+  this->tilt_value = value;
+  this->write_command(COVER_COMMAND_TILT, value);
+}
 uint32_t Cover::hash_base() { return 1727367479UL; }
 #ifdef USE_MQTT_COVER
 MQTTCoverComponent *Cover::get_mqtt() const { return this->mqtt_; }

--- a/src/esphome/cover/cover.h
+++ b/src/esphome/cover/cover.h
@@ -120,8 +120,8 @@ class Cover : public Nameable {
   float position_open_{100.0};
   float tilt_min_{0.0};
   float tilt_max_{100.0};
-  float tilt_closed_value_{100.0};
-  float tilt_opened_value_{0.0};
+  float tilt_closed_value_{0.0};
+  float tilt_opened_value_{100.0};
   bool tilt_invert_state_{false};
   bool optimistic_{false};
 

--- a/src/esphome/cover/mqtt_cover_component.cpp
+++ b/src/esphome/cover/mqtt_cover_component.cpp
@@ -28,19 +28,133 @@ void MQTTCoverComponent::setup() {
       ESP_LOGW(TAG, "'%s': Received unknown payload '%s'...", this->friendly_name().c_str(), payload.c_str());
     }
   });
+  this->subscribe(this->position_command_topic(), [this](const std::string &topic, const std::string payload) {
+      ESP_LOGD(TAG, "'%s': Setting position = %s", this->friendly_name().c_str(), payload.c_str());
+      auto val = atof(payload.c_str());
+      // TODO: Handle errors
+      this->cover_->set_position(val);
+      if (cover_->optimistic()) {
+        this->publish_position(val);
+        if (this->custom_command_topic_.empty()) { // if no open/closed command then position sets state
+          if (val <= cover_->position_closed())
+    	    this->publish_state(COVER_CLOSED);
+          else
+    	    this->publish_state(COVER_OPEN);
+        }
+      }
+  });
+  this->subscribe(this->tilt_command_topic(), [this](const std::string &topic, const std::string payload) {
+      ESP_LOGD(TAG, "'%s': Setting tilt = %s", this->friendly_name().c_str(), payload.c_str());
+      auto val = atof(payload.c_str());
+      // TODO: Handle errors
+      this->cover_->set_tilt(val);
+      if (cover_->optimistic()) {
+        this->publish_tilt(val);
+        if (this->custom_position_command_topic_.empty()) { // if no position then tilt sets state
+          if (
+              (val <= cover_->tilt_closed_value() && !cover_->tilt_invert_state()) ||
+              (val >= cover_->tilt_closed_value() && cover_->tilt_invert_state())
+          )
+            this->publish_state(COVER_CLOSED);
+          else
+            this->publish_state(COVER_OPEN);
+        }
+      }
+  });
 }
 
 void MQTTCoverComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "MQTT cover '%s':", this->cover_->get_name().c_str());
-  LOG_MQTT_COMPONENT(true, true)
+  if (!this->custom_command_topic_.empty())
+    ESP_LOGCONFIG(TAG, "  Command Topic '%s':", this->custom_command_topic_.c_str());
+  if (!this->custom_state_topic_.empty())
+    ESP_LOGCONFIG(TAG, "  State Topic '%s':", this->custom_state_topic_.c_str());
+  if (!this->custom_position_command_topic_.empty())
+    ESP_LOGCONFIG(TAG, "  Position Command Topic '%s':", this->custom_position_command_topic_.c_str());
+  if (!this->custom_position_state_topic_.empty())
+    ESP_LOGCONFIG(TAG, "  Position State Topic '%s':", this->custom_position_state_topic_.c_str());
+  if (!this->custom_tilt_command_topic_.empty())
+    ESP_LOGCONFIG(TAG, "  Tilt Command Topic '%s':", this->custom_tilt_command_topic_.c_str());
+  if (!this->custom_tilt_status_topic_.empty())
+    ESP_LOGCONFIG(TAG, "  Tilt Status Topic '%s':", this->custom_tilt_status_topic_.c_str());
 }
 void MQTTCoverComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryConfig &config) {
+  if (this->custom_command_topic_.empty()) {
+//    config.state_topic = false;
+    config.command_topic = false;
+  }
   if (this->cover_->assumed_state())
     root["optimistic"] = true;
+  if (!this->custom_position_command_topic_.empty()) {
+    root["set_position_topic"] = this->position_command_topic();
+    root["position_topic"] = this->position_state_topic();
+    root["position_closed"] = this->cover_->position_closed();
+    root["position_open"] = this->cover_->position_open();
+  }
+  if (!this->custom_tilt_command_topic_.empty()) {
+    root["tilt_command_topic"] = this->tilt_command_topic();
+    root["tilt_status_topic"] = this->tilt_status_topic();
+    root["tilt_min"] = this->cover_->tilt_min();
+    root["tilt_max"] = this->cover_->tilt_max();
+    root["tilt_closed_value"] = this->cover_->tilt_closed_value();
+    root["tilt_opened_value"] = this->cover_->tilt_opened_value();
+    root["tilt_invert_state"] = this->cover_->tilt_invert_state();
+  }
+  root["optimistic"] = this-cover_->optimistic();
 }
 
 std::string MQTTCoverComponent::component_type() const { return "cover"; }
 std::string MQTTCoverComponent::friendly_name() const { return this->cover_->get_name(); }
+
+void MQTTCoverComponent::set_custom_command_topic(const std::string &topic) {
+  this->custom_command_topic_ = topic;
+}
+void MQTTCoverComponent::set_custom_state_topic(const std::string &topic) {
+  this->custom_state_topic_ = topic;
+}
+void MQTTCoverComponent::set_custom_position_command_topic(const std::string &topic) {
+  this->custom_position_command_topic_ = topic;
+}
+void MQTTCoverComponent::set_custom_position_state_topic(const std::string &topic) {
+  this->custom_position_state_topic_ = topic;
+}
+void MQTTCoverComponent::set_custom_tilt_command_topic(const std::string &topic) {
+  this->custom_tilt_command_topic_ = topic;
+}
+void MQTTCoverComponent::set_custom_tilt_status_topic(const std::string &topic) {
+  this->custom_tilt_status_topic_ = topic;
+}
+const std::string MQTTCoverComponent::command_topic() const {
+  if (this->custom_command_topic_.empty())
+    return this->get_default_topic_for_("command");
+  return this->custom_command_topic_;
+}
+const std::string MQTTCoverComponent::state_topic() const {
+  if (this->custom_state_topic_.empty())
+    return this->get_default_topic_for_("state");
+  return this->custom_state_topic_;
+}
+const std::string MQTTCoverComponent::position_command_topic() const {
+  if (this->custom_position_command_topic_.empty())
+    return this->get_default_topic_for_("position/command");
+  return this->custom_position_command_topic_;
+}
+const std::string MQTTCoverComponent::position_state_topic() const {
+  if (this->custom_position_state_topic_.empty())
+    return this->get_default_topic_for_("position/state");
+  return this->custom_position_state_topic_;
+}
+const std::string MQTTCoverComponent::tilt_command_topic() const {
+  if (this->custom_tilt_command_topic_.empty())
+    return this->get_default_topic_for_("tilt/command");
+  return this->custom_tilt_command_topic_;
+}
+const std::string MQTTCoverComponent::tilt_status_topic() const {
+  if (this->custom_tilt_status_topic_.empty())
+    return this->get_default_topic_for_("tilt/state");
+  return this->custom_tilt_status_topic_;
+}
+
 bool MQTTCoverComponent::send_initial_state() {
   if (this->cover_->has_state()) {
     return this->publish_state(this->cover_->state);
@@ -65,6 +179,22 @@ bool MQTTCoverComponent::publish_state(cover::CoverState state) {
   }
   ESP_LOGD(TAG, "'%s': Sending state %s", this->friendly_name().c_str(), state_s);
   return this->publish(this->get_state_topic_(), state_s);
+}
+bool MQTTCoverComponent::publish_position(float position_value) {
+  const char *position_buf;
+  char buf[64];
+  sprintf(buf, "%.0f", position_value);
+  position_buf = buf;
+  ESP_LOGD(TAG, "'%s': Sending position = %s", this->friendly_name().c_str(), position_buf);
+  return this->publish(this->position_state_topic(), position_buf);
+}
+bool MQTTCoverComponent::publish_tilt(float tilt_value) {
+  const char *tilt_buf;
+  char buf[64];
+  sprintf(buf, "%.0f", tilt_value);
+  tilt_buf = buf;
+  ESP_LOGD(TAG, "'%s': Sending tilt = %s", this->friendly_name().c_str(), tilt_buf);
+  return this->publish(this->tilt_status_topic(), tilt_buf);
 }
 
 }  // namespace cover

--- a/src/esphome/cover/mqtt_cover_component.h
+++ b/src/esphome/cover/mqtt_cover_component.h
@@ -23,12 +23,34 @@ class MQTTCoverComponent : public mqtt::MQTTComponent {
   bool is_internal() override;
 
   bool publish_state(cover::CoverState state);
+  bool publish_position(cover::position_value_t position_value);
+  bool publish_tilt(cover::tilt_value_t tilt_value);
 
   void dump_config() override;
+
+  void set_custom_command_topic(const std::string &topic);
+  void set_custom_state_topic(const std::string &topic);
+  void set_custom_position_command_topic(const std::string &topic);
+  void set_custom_position_state_topic(const std::string &topic);
+  void set_custom_tilt_command_topic(const std::string &topic);
+  void set_custom_tilt_status_topic(const std::string &topic);
+
+  const std::string command_topic() const;
+  const std::string state_topic() const;
+  const std::string position_command_topic() const;
+  const std::string position_state_topic() const;
+  const std::string tilt_command_topic() const;
+  const std::string tilt_status_topic() const;
 
  protected:
   std::string component_type() const override;
   std::string friendly_name() const override;
+  std::string custom_command_topic_;
+  std::string custom_state_topic_;
+  std::string custom_position_command_topic_;
+  std::string custom_position_state_topic_;
+  std::string custom_tilt_command_topic_;
+  std::string custom_tilt_status_topic_;
 
   Cover *cover_;
 };

--- a/src/esphome/cover/template_cover.cpp
+++ b/src/esphome/cover/template_cover.cpp
@@ -12,7 +12,8 @@ namespace cover {
 static const char *TAG = "cover.template";
 
 TemplateCover::TemplateCover(const std::string &name)
-    : Cover(name), open_trigger_(new Trigger<>()), close_trigger_(new Trigger<>), stop_trigger_(new Trigger<>()) {}
+    : Cover(name), open_trigger_(new Trigger<>()), close_trigger_(new Trigger<>()), stop_trigger_(new Trigger<>()), \
+	  position_trigger_(new Trigger<>()), tilt_trigger_(new Trigger<>()){}
 void TemplateCover::loop() {
   if (!this->f_.has_value())
     return;
@@ -21,15 +22,34 @@ void TemplateCover::loop() {
     return;
 
   this->publish_state(*s);
+
+  if (!this->p_.has_value())
+    return;
+  auto ps = (*this->p_)();
+  if (!ps.has_value())
+    return;
+
+  this->publish_position(*ps);
+
+  if (!this->t_.has_value())
+    return;
+  auto ts = (*this->t_)();
+  if (!ts.has_value())
+    return;
+
+  this->publish_tilt(*ts);
 }
-void TemplateCover::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 void TemplateCover::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 bool TemplateCover::assumed_state() { return this->assumed_state_; }
 void TemplateCover::set_state_lambda(std::function<optional<CoverState>()> &&f) { this->f_ = f; }
+void TemplateCover::set_position_lambda(std::function<optional<position_value_t>()> &&p) { this->p_ = p; }
+void TemplateCover::set_tilt_lambda(std::function<optional<tilt_value_t>()> &&t) { this->t_ = t; }
 float TemplateCover::get_setup_priority() const { return setup_priority::HARDWARE; }
 Trigger<> *TemplateCover::get_open_trigger() const { return this->open_trigger_; }
 Trigger<> *TemplateCover::get_close_trigger() const { return this->close_trigger_; }
 Trigger<> *TemplateCover::get_stop_trigger() const { return this->stop_trigger_; }
+Trigger<> *TemplateCover::get_position_trigger() const { return this->position_trigger_; }
+Trigger<> *TemplateCover::get_tilt_trigger() const { return this->tilt_trigger_; }
 void TemplateCover::write_command(CoverCommand command) {
   if (this->prev_trigger_ != nullptr) {
     this->prev_trigger_->stop();
@@ -54,8 +74,47 @@ void TemplateCover::write_command(CoverCommand command) {
       this->stop_trigger_->trigger();
       break;
     }
+    case COVER_COMMAND_POSITION: {
+      break;
+    }
+    case COVER_COMMAND_TILT: {
+      break;
+    }
   }
 }
+
+void TemplateCover::write_command(CoverCommand command, float value) {
+  switch (command) {
+    case COVER_COMMAND_OPEN: {
+      break;
+    }
+    case COVER_COMMAND_CLOSE: {
+      break;
+    }
+    case COVER_COMMAND_STOP: {
+      break;
+    }
+    case COVER_COMMAND_POSITION: {
+      this->position_value = value;
+      this->prev_trigger_ = this->position_trigger_;
+      this->position_trigger_->trigger();
+      ESP_LOGD(TAG, "Template Cover: Triggering position update to %f", value);
+      if (this->optimistic())
+        this->publish_position(position_value);
+      break;
+    }
+    case COVER_COMMAND_TILT: {
+      this->tilt_value = value;
+      this->prev_trigger_ = this->tilt_trigger_;
+      this->tilt_trigger_->trigger();
+      ESP_LOGD(TAG, "Template Cover: Triggering tilt update to %f", value);
+      if (this->optimistic())
+        this->publish_tilt(tilt_value);
+      break;
+    }
+  }
+}
+
 void TemplateCover::dump_config() { LOG_COVER("", "Template Cover", this); }
 
 }  // namespace cover

--- a/src/esphome/cover/template_cover.h
+++ b/src/esphome/cover/template_cover.h
@@ -17,27 +17,37 @@ class TemplateCover : public Cover, public Component {
   explicit TemplateCover(const std::string &name);
 
   void set_state_lambda(std::function<optional<CoverState>()> &&f);
+  void set_position_lambda(std::function<optional<position_value_t>()> &&p);
+  void set_tilt_lambda(std::function<optional<tilt_value_t>()> &&t);
   Trigger<> *get_open_trigger() const;
   Trigger<> *get_close_trigger() const;
   Trigger<> *get_stop_trigger() const;
-  void set_optimistic(bool optimistic);
+  Trigger<> *get_position_trigger() const;
+  Trigger<> *get_tilt_trigger() const;
   void set_assumed_state(bool assumed_state);
 
   void loop() override;
   void dump_config() override;
 
   float get_setup_priority() const override;
+  position_value_t position_value;
+  tilt_value_t tilt_value;
 
  protected:
   void write_command(CoverCommand command) override;
+  void write_command(CoverCommand command, float value) override;
   bool assumed_state() override;
 
   optional<std::function<optional<CoverState>()>> f_;
+  optional<std::function<optional<position_value_t>()>> p_;
+  optional<std::function<optional<tilt_value_t>()>> t_;
   bool assumed_state_{false};
   bool optimistic_{false};
   Trigger<> *open_trigger_;
   Trigger<> *close_trigger_;
   Trigger<> *stop_trigger_;
+  Trigger<> *position_trigger_;
+  Trigger<> *tilt_trigger_;
   Trigger<> *prev_trigger_{nullptr};
 };
 


### PR DESCRIPTION
## Description:
This is my initial working version of adding position and tilt setting capabilities to the existing template cover component. This version works in optimistic mode but I think it is not working properly with lambdas to generate position and tilt states. Please review and set me on the right path.

**Related issue (if applicable):** fixes [feature-request #42](https://github.com/esphome/feature-requests/issues/42)

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [X] The code change is tested and works locally.
  - [X] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
