### PR TITLE
Rewrite PN532 to fix some lowvbat issues

### DIFF
--- a/src/esphome/binary_sensor/pn532_component.cpp
+++ b/src/esphome/binary_sensor/pn532_component.cpp
@@ -70,10 +70,10 @@ void PN532Component::setup() {
   // Set up SAM (secure access module)
   uint8_t sam_timeout = std::min(255u, this->update_interval_ / 50);
   bool ret = this->pn532_write_command_check_ack_({
-      0x14,  // SAM config command
-      0x01,  // normal mode
+      0x14,         // SAM config command
+      0x01,         // normal mode
       sam_timeout,  // timeout as multiple of 50ms (actually only for virtual card mode, but shouldn't matter)
-      0x01,  // Enable IRQ
+      0x01,         // Enable IRQ
   });
 
   if (!ret) {
@@ -84,7 +84,7 @@ void PN532Component::setup() {
 
   auto sam_result = this->pn532_read_data_();
   if (sam_result.size() != 1) {
-    ESP_LOGV(TAG, "Invalid SAM result: (%u)", sam_result.size());
+    ESP_LOGV(TAG, "Invalid SAM result: (%zu)", sam_result.size());
     for (auto dat : sam_result) {
       ESP_LOGV(TAG, " 0x%02X", dat);
     }
@@ -294,7 +294,7 @@ std::vector<uint8_t> PN532Component::pn532_read_data_() {
   this->disable();
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-  ESP_LOGVV(TAG, "PN532 Data Frame: (%u)", ret.size());
+  ESP_LOGVV(TAG, "PN532 Data Frame: (%zu)", ret.size());
   for (uint8_t dat : ret) {
     ESP_LOGVV(TAG, "  0x%02X", dat);
   }


### PR DESCRIPTION
## Description:

Code is now directly based on datasheet+application notes by nxp. This should make the PN532 integration a lot more robust.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
