### PR TITLE
Fix neopixelbus logging causes section type conflict

### DIFF
--- a/src/esphome/light/neo_pixel_bus_light_output.tcc
+++ b/src/esphome/light/neo_pixel_bus_light_output.tcc
@@ -50,7 +50,6 @@ void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::add_leds(
 }
 template<typename T_METHOD, typename T_COLOR_FEATURE>
 void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up NeoPixelBus light...");
   for (int i = 0; i < this->size(); i++) {
     (*this)[i] = ESPColor(0, 0, 0, 0);
   }
@@ -60,8 +59,6 @@ void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::setup() {
 }
 template<typename T_METHOD, typename T_COLOR_FEATURE>
 void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::dump_config() {
-  ESP_LOGCONFIG(TAG, "NeoPixelBus light:");
-  ESP_LOGCONFIG(TAG, "  Num LEDs: %u", this->controller_->PixelCount());
 }
 template<typename T_METHOD, typename T_COLOR_FEATURE>
 void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::loop() {
@@ -92,7 +89,6 @@ void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::loop() {
   }
 #endif
 
-  ESP_LOGVV(TAG, "Writing RGB values to bus...");
   this->controller_->Show();
 }
 template<typename T_METHOD, typename T_COLOR_FEATURE>

--- a/src/esphome/light/neo_pixel_bus_light_output.tcc
+++ b/src/esphome/light/neo_pixel_bus_light_output.tcc
@@ -58,8 +58,7 @@ void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::setup() {
   this->controller_->Begin();
 }
 template<typename T_METHOD, typename T_COLOR_FEATURE>
-void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::dump_config() {
-}
+void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::dump_config() {}
 template<typename T_METHOD, typename T_COLOR_FEATURE>
 void NeoPixelBusLightOutputBase<T_METHOD, T_COLOR_FEATURE>::loop() {
   if (!this->should_show_())


### PR DESCRIPTION
Fixes https://github.com/esphome/issues/issues/182

We can't have logging in header files - especially now with ESP8266 log strings in flash

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [ ] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
