### PR TITLE
Add SM16716 output component.

### DIFF
--- a/src/esphome/application.cpp
+++ b/src/esphome/application.cpp
@@ -273,9 +273,9 @@ MY9231OutputComponent *Application::make_my9231_component(const GPIOOutputPin &p
 #endif
 
 #ifdef USE_SM16716_OUTPUT
-SM16716OutputComponent *Application::make_sm16716_component(const GPIOOutputPin &pin_mosi,
-                                                            const GPIOOutputPin &pin_sclk) {
-  auto *sm16716 = new SM16716OutputComponent(pin_mosi.copy(), pin_sclk.copy());
+SM16716OutputComponent *Application::make_sm16716_component(const GPIOOutputPin &pin_data,
+                                                            const GPIOOutputPin &pin_clock) {
+  auto *sm16716 = new SM16716OutputComponent(pin_data.copy(), pin_clock.copy());
   return this->register_component(sm16716);
 }
 #endif

--- a/src/esphome/application.cpp
+++ b/src/esphome/application.cpp
@@ -272,6 +272,13 @@ MY9231OutputComponent *Application::make_my9231_component(const GPIOOutputPin &p
 }
 #endif
 
+#ifdef USE_SM16716_OUTPUT
+SM16716OutputComponent *Application::make_sm16716_component(const GPIOOutputPin &pin_mosi, const GPIOOutputPin &pin_sclk) {
+  auto *sm16716 = new SM16716OutputComponent(pin_mosi.copy(), pin_sclk.copy());
+  return this->register_component(sm16716);
+}
+#endif
+
 #ifdef USE_LIGHT
 Application::MakeLight Application::make_rgb_light(const std::string &friendly_name, FloatOutput *red,
                                                    FloatOutput *green, FloatOutput *blue) {

--- a/src/esphome/application.cpp
+++ b/src/esphome/application.cpp
@@ -273,7 +273,8 @@ MY9231OutputComponent *Application::make_my9231_component(const GPIOOutputPin &p
 #endif
 
 #ifdef USE_SM16716_OUTPUT
-SM16716OutputComponent *Application::make_sm16716_component(const GPIOOutputPin &pin_mosi, const GPIOOutputPin &pin_sclk) {
+SM16716OutputComponent *Application::make_sm16716_component(const GPIOOutputPin &pin_mosi,
+                                                            const GPIOOutputPin &pin_sclk) {
   auto *sm16716 = new SM16716OutputComponent(pin_mosi.copy(), pin_sclk.copy());
   return this->register_component(sm16716);
 }

--- a/src/esphome/application.h
+++ b/src/esphome/application.h
@@ -909,11 +909,11 @@ class Application {
 #ifdef USE_SM16716_OUTPUT
   /** Create a SM16716 component.
    *
-   * @param pin_mosi The pin which MOSI (master out slave in) is connected to.
-   * @param pin_sclk The pin which SCLK (serial clock) is connected to.
+   * @param pin_data The data output pin, connected to the SM16716's DIN pin.
+   * @param pin_clock The clock pin, connected to the SM16716's DCLK pin.
    * @return The SM16716 component. Use this for advanced settings.
    */
-  output::SM16716OutputComponent *make_sm16716_component(const GPIOOutputPin &pin_mosi, const GPIOOutputPin &pin_sclk);
+  output::SM16716OutputComponent *make_sm16716_component(const GPIOOutputPin &pin_data, const GPIOOutputPin &pin_clock);
 #endif
 
   /*   _     ___ ____ _   _ _____

--- a/src/esphome/application.h
+++ b/src/esphome/application.h
@@ -74,6 +74,7 @@
 #include "esphome/output/ledc_output_component.h"
 #include "esphome/output/pca9685_output_component.h"
 #include "esphome/output/my9231_output_component.h"
+#include "esphome/output/sm16716_output_component.h"
 #include "esphome/remote/jvc.h"
 #include "esphome/remote/lg.h"
 #include "esphome/remote/nec.h"
@@ -903,6 +904,16 @@ class Application {
    * @return The MY9231 component. Use this for advanced settings.
    */
   output::MY9231OutputComponent *make_my9231_component(const GPIOOutputPin &pin_di, const GPIOOutputPin &pin_dcki);
+#endif
+
+#ifdef USE_SM16716_OUTPUT
+  /** Create a SM16716 component.
+   *
+   * @param pin_mosi The pin which MOSI (master out slave in) is connected to.
+   * @param pin_sclk The pin which SCLK (serial clock) is connected to.
+   * @return The SM16716 component. Use this for advanced settings.
+   */
+  output::SM16716OutputComponent *make_sm16716_component(const GPIOOutputPin &pin_mosi, const GPIOOutputPin &pin_sclk);
 #endif
 
   /*   _     ___ ____ _   _ _____

--- a/src/esphome/defines.h
+++ b/src/esphome/defines.h
@@ -129,6 +129,7 @@
 #define USE_ULN2003
 #define USE_TOTAL_DAILY_ENERGY_SENSOR
 #define USE_MY9231_OUTPUT
+#define USE_SM16716_OUTPUT
 #define USE_CUSTOM_SENSOR
 #define USE_CUSTOM_BINARY_SENSOR
 #define USE_CUSTOM_OUTPUT
@@ -219,6 +220,11 @@
 #endif
 #endif
 #ifdef USE_MY9231_OUTPUT
+#ifndef USE_OUTPUT
+#define USE_OUTPUT
+#endif
+#endif
+#ifdef USE_SM16716_OUTPUT
 #ifndef USE_OUTPUT
 #define USE_OUTPUT
 #endif

--- a/src/esphome/defines.h
+++ b/src/esphome/defines.h
@@ -224,11 +224,6 @@
 #define USE_OUTPUT
 #endif
 #endif
-#ifdef USE_SM16716_OUTPUT
-#ifndef USE_OUTPUT
-#define USE_OUTPUT
-#endif
-#endif
 
 #ifdef USE_APDS9960
 #ifndef USE_SENSOR

--- a/src/esphome/output/sm16716_output_component.cpp
+++ b/src/esphome/output/sm16716_output_component.cpp
@@ -22,11 +22,7 @@ static const char *TAG = "output.sm16716";
 
 SM16716OutputComponent::SM16716OutputComponent(GPIOPin *pin_data, GPIOPin *pin_clock, uint8_t num_channels,
                                                uint8_t num_chips, bool update)
-    : pin_data_(pin_data),
-      pin_clock_(pin_clock),
-      num_channels_(num_channels),
-      num_chips_(num_chips),
-      update_(update) {}
+    : pin_data_(pin_data), pin_clock_(pin_clock), num_channels_(num_channels), num_chips_(num_chips), update_(update) {}
 
 void SM16716OutputComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM16716OutputComponent...");
@@ -64,13 +60,13 @@ void SM16716OutputComponent::loop() {
     this->write_byte_(this->pwm_amounts_[index]);
     index++;
   }
-  
+
   // send a blank 25 bits to signal the end
   this->write_bit_(false);
   this->write_byte_(0);
   this->write_byte_(0);
   this->write_byte_(0);
-  
+
   this->update_ = false;
 }
 
@@ -119,7 +115,7 @@ SM16716OutputComponent::Channel::Channel(SM16716OutputComponent *parent, uint8_t
     : FloatOutput(), parent_(parent), channel_(channel) {}
 
 void SM16716OutputComponent::Channel::write_state(float state) {
-  uint8_t amount = state * 0xFF;
+  auto amount = uint8_t(state * 0xFF);
   this->parent_->set_channel_value_(this->channel_, amount);
 }
 

--- a/src/esphome/output/sm16716_output_component.cpp
+++ b/src/esphome/output/sm16716_output_component.cpp
@@ -1,0 +1,128 @@
+// Based on:
+//   - The SM16716 implementation from this repository.
+//   - The Tasmota SM16716 implementation: https://github.com/arendst/Sonoff-Tasmota/blob/master/sonoff/xdrv_04_light.ino
+//   - This older implementation: https://github.com/sowbug/sm16716
+//   - The datasheet (in Chinese only): https://github.com/sowbug/sm16716/blob/master/SM16716%20Datasheet%20%5BChinese%5D.pdf
+
+#include "esphome/defines.h"
+
+#ifdef USE_SM16716_OUTPUT
+
+#include "esphome/log.h"
+#include "esphome/output/sm16716_output_component.h"
+
+ESPHOME_NAMESPACE_BEGIN
+
+namespace output {
+
+static const char *TAG = "output.sm16716";
+
+SM16716OutputComponent::SM16716OutputComponent(GPIOPin *pin_mosi, GPIOPin *pin_sclk,
+                                               uint8_t num_channels, uint8_t num_chips,
+                                               bool update)
+    : pin_mosi_(pin_mosi),
+      pin_sclk_(pin_sclk),
+      num_channels_(num_channels),
+      num_chips_(num_chips),
+      update_(update) {}
+
+void SM16716OutputComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up SM16716OutputComponent...");
+  this->pin_mosi_->setup();
+  this->pin_mosi_->digital_write(false);
+  this->pin_sclk_->setup();
+  this->pin_sclk_->digital_write(false);
+  this->pwm_amounts_.resize(this->num_channels_, 0);
+}
+void SM16716OutputComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "SM16716:");
+  LOG_PIN("  DIN Pin: ", this->pin_mosi_);
+  LOG_PIN("  DCLK Pin: ", this->pin_sclk_);
+  ESP_LOGCONFIG(TAG, "  Total number of channels: %u", this->num_channels_);
+  ESP_LOGCONFIG(TAG, "  Number of chips: %u", this->num_chips_);
+}
+
+void SM16716OutputComponent::loop() {
+  if (!this->update_) {
+    return;
+  }
+
+  for (uint8_t i = 0; i < 50; i++) {
+    this->write_bit_(0);
+  }
+
+  // send 25 bits (1 start bit plus 24 data bits) for each chip
+  uint8_t index = 0;
+  while (index < this->num_channels_) {
+    // send a start bit initially and after every 3 channels
+    if (index % 3 == 0) {
+      this->write_bit_(1);
+    }
+
+    this->write_byte_(this->pwm_amounts_[index]);
+    index++;
+  }
+  
+  // send a blank 25 bits to signal the end
+  this->write_bit_(0);
+  this->write_byte_(0);
+  this->write_byte_(0);
+  this->write_byte_(0);
+  
+  this->update_ = false;
+}
+
+SM16716OutputComponent::Channel *SM16716OutputComponent::create_channel(uint8_t channel,
+                                                                      PowerSupplyComponent *power_supply,
+                                                                      float max_power) {
+  ESP_LOGV(TAG, "Getting channel %d...", channel);
+  auto *c = new Channel(this, channel);
+  c->set_power_supply(power_supply);
+  c->set_max_power(max_power);
+  return c;
+}
+
+float SM16716OutputComponent::get_setup_priority() const { return setup_priority::HARDWARE; }
+
+void SM16716OutputComponent::set_channel_value_(uint8_t channel, uint8_t value) {
+  ESP_LOGV(TAG, "set channels %u to %u", channel, value);
+  uint8_t index = this->num_channels_ - channel - 1;
+  if (this->pwm_amounts_[index] != value) {
+    this->update_ = true;
+  }
+  this->pwm_amounts_[index] = value;
+}
+
+void SM16716OutputComponent::write_bit_(bool value) {
+  this->pin_mosi_->digital_write(value);
+  this->pin_sclk_->digital_write(true);
+  this->pin_sclk_->digital_write(false);
+}
+
+void SM16716OutputComponent::write_byte_(uint8_t data) {
+  shiftOut(this->pin_mosi_->get_pin(), this->pin_sclk_->get_pin(), MSBFIRST, data);
+}
+
+void SM16716OutputComponent::set_num_channels(uint8_t num_channels) { this->num_channels_ = num_channels; }
+
+uint8_t SM16716OutputComponent::get_num_channels() const { return this->num_channels_; }
+
+void SM16716OutputComponent::set_num_chips(uint8_t num_chips) { this->num_chips_ = num_chips; }
+
+uint8_t SM16716OutputComponent::get_num_chips() const { return this->num_chips_; }
+
+void SM16716OutputComponent::set_update(bool update) { this->update_ = update; }
+
+SM16716OutputComponent::Channel::Channel(SM16716OutputComponent *parent, uint8_t channel)
+    : FloatOutput(), parent_(parent), channel_(channel) {}
+
+void SM16716OutputComponent::Channel::write_state(float state) {
+  uint8_t amount = state * 0xFF;
+  this->parent_->set_channel_value_(this->channel_, amount);
+}
+
+}  // namespace output
+
+ESPHOME_NAMESPACE_END
+
+#endif  // USE_SM16716_OUTPUT

--- a/src/esphome/output/sm16716_output_component.cpp
+++ b/src/esphome/output/sm16716_output_component.cpp
@@ -1,8 +1,11 @@
 // Based on:
 //   - The SM16716 implementation from this repository.
-//   - The Tasmota SM16716 implementation: https://github.com/arendst/Sonoff-Tasmota/blob/master/sonoff/xdrv_04_light.ino
-//   - This older implementation: https://github.com/sowbug/sm16716
-//   - The datasheet (in Chinese only): https://github.com/sowbug/sm16716/blob/master/SM16716%20Datasheet%20%5BChinese%5D.pdf
+//   - The Tasmota SM16716 implementation:
+//     https://github.com/arendst/Sonoff-Tasmota/blob/master/sonoff/xdrv_04_light.ino
+//   - This older implementation:
+//     https://github.com/sowbug/sm16716
+//   - The datasheet (in Chinese only):
+//     https://github.com/sowbug/sm16716/blob/master/SM16716%20Datasheet%20%5BChinese%5D.pdf
 
 #include "esphome/defines.h"
 
@@ -17,9 +20,8 @@ namespace output {
 
 static const char *TAG = "output.sm16716";
 
-SM16716OutputComponent::SM16716OutputComponent(GPIOPin *pin_mosi, GPIOPin *pin_sclk,
-                                               uint8_t num_channels, uint8_t num_chips,
-                                               bool update)
+SM16716OutputComponent::SM16716OutputComponent(GPIOPin *pin_mosi, GPIOPin *pin_sclk, uint8_t num_channels,
+                                               uint8_t num_chips, bool update)
     : pin_mosi_(pin_mosi),
       pin_sclk_(pin_sclk),
       num_channels_(num_channels),
@@ -48,7 +50,7 @@ void SM16716OutputComponent::loop() {
   }
 
   for (uint8_t i = 0; i < 50; i++) {
-    this->write_bit_(0);
+    this->write_bit_(false);
   }
 
   // send 25 bits (1 start bit plus 24 data bits) for each chip
@@ -56,7 +58,7 @@ void SM16716OutputComponent::loop() {
   while (index < this->num_channels_) {
     // send a start bit initially and after every 3 channels
     if (index % 3 == 0) {
-      this->write_bit_(1);
+      this->write_bit_(true);
     }
 
     this->write_byte_(this->pwm_amounts_[index]);
@@ -64,7 +66,7 @@ void SM16716OutputComponent::loop() {
   }
   
   // send a blank 25 bits to signal the end
-  this->write_bit_(0);
+  this->write_bit_(false);
   this->write_byte_(0);
   this->write_byte_(0);
   this->write_byte_(0);
@@ -73,8 +75,8 @@ void SM16716OutputComponent::loop() {
 }
 
 SM16716OutputComponent::Channel *SM16716OutputComponent::create_channel(uint8_t channel,
-                                                                      PowerSupplyComponent *power_supply,
-                                                                      float max_power) {
+                                                                        PowerSupplyComponent *power_supply,
+                                                                        float max_power) {
   ESP_LOGV(TAG, "Getting channel %d...", channel);
   auto *c = new Channel(this, channel);
   c->set_power_supply(power_supply);

--- a/src/esphome/output/sm16716_output_component.cpp
+++ b/src/esphome/output/sm16716_output_component.cpp
@@ -49,8 +49,7 @@ void SM16716OutputComponent::loop() {
   }
 
   // send 25 bits (1 start bit plus 24 data bits) for each chip
-  for (uint8_t index = 0; index < this->num_channels_; index++)
-  {
+  for (uint8_t index = 0; index < this->num_channels_; index++) {
     // send a start bit initially and after every 3 channels
     if (index % 3 == 0) {
       this->write_bit_(true);

--- a/src/esphome/output/sm16716_output_component.cpp
+++ b/src/esphome/output/sm16716_output_component.cpp
@@ -20,26 +20,26 @@ namespace output {
 
 static const char *TAG = "output.sm16716";
 
-SM16716OutputComponent::SM16716OutputComponent(GPIOPin *pin_mosi, GPIOPin *pin_sclk, uint8_t num_channels,
+SM16716OutputComponent::SM16716OutputComponent(GPIOPin *pin_data, GPIOPin *pin_clock, uint8_t num_channels,
                                                uint8_t num_chips, bool update)
-    : pin_mosi_(pin_mosi),
-      pin_sclk_(pin_sclk),
+    : pin_data_(pin_data),
+      pin_clock_(pin_clock),
       num_channels_(num_channels),
       num_chips_(num_chips),
       update_(update) {}
 
 void SM16716OutputComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SM16716OutputComponent...");
-  this->pin_mosi_->setup();
-  this->pin_mosi_->digital_write(false);
-  this->pin_sclk_->setup();
-  this->pin_sclk_->digital_write(false);
+  this->pin_data_->setup();
+  this->pin_data_->digital_write(false);
+  this->pin_clock_->setup();
+  this->pin_clock_->digital_write(false);
   this->pwm_amounts_.resize(this->num_channels_, 0);
 }
 void SM16716OutputComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "SM16716:");
-  LOG_PIN("  DIN Pin: ", this->pin_mosi_);
-  LOG_PIN("  DCLK Pin: ", this->pin_sclk_);
+  LOG_PIN("  DATA Pin: ", this->pin_data_);
+  LOG_PIN("  CLOCK Pin: ", this->pin_clock_);
   ESP_LOGCONFIG(TAG, "  Total number of channels: %u", this->num_channels_);
   ESP_LOGCONFIG(TAG, "  Number of chips: %u", this->num_chips_);
 }
@@ -96,13 +96,13 @@ void SM16716OutputComponent::set_channel_value_(uint8_t channel, uint8_t value) 
 }
 
 void SM16716OutputComponent::write_bit_(bool value) {
-  this->pin_mosi_->digital_write(value);
-  this->pin_sclk_->digital_write(true);
-  this->pin_sclk_->digital_write(false);
+  this->pin_data_->digital_write(value);
+  this->pin_clock_->digital_write(true);
+  this->pin_clock_->digital_write(false);
 }
 
 void SM16716OutputComponent::write_byte_(uint8_t data) {
-  shiftOut(this->pin_mosi_->get_pin(), this->pin_sclk_->get_pin(), MSBFIRST, data);
+  shiftOut(this->pin_data_->get_pin(), this->pin_clock_->get_pin(), MSBFIRST, data);
 }
 
 void SM16716OutputComponent::set_num_channels(uint8_t num_channels) { this->num_channels_ = num_channels; }

--- a/src/esphome/output/sm16716_output_component.h
+++ b/src/esphome/output/sm16716_output_component.h
@@ -24,8 +24,7 @@ class SM16716OutputComponent : public Component {
    * @param update Update/reset duty data at boot (driver will keep
    *               configuration after powercycle)
    */
-  SM16716OutputComponent(GPIOPin *pin_data, GPIOPin *pin_clock, uint8_t num_channels = 3, uint8_t num_chips = 1,
-                         bool update = true);
+  SM16716OutputComponent(GPIOPin *pin_data, GPIOPin *pin_clock);
 
   /** Get a SM16716 output channel.
    *
@@ -40,21 +39,18 @@ class SM16716OutputComponent : public Component {
 
   /// Manually set the total number of channels. Defaults to 3.
   void set_num_channels(uint8_t num_channels);
+  
   /// Manually set the number of chips. Defaults to 1.
   void set_num_chips(uint8_t num_chips);
-  /// Manually set duty data update on boot. Defaults is true.
-  void set_update(bool update);
-
-  // ========== INTERNAL METHODS ==========
-  // (In most use cases you won't need these)
-  uint8_t get_num_channels() const;
-  uint8_t get_num_chips() const;
 
   /// Setup the SM16716.
   void setup() override;
+  
   void dump_config() override;
+  
   /// HARDWARE setup_priority
   float get_setup_priority() const override;
+  
   /// Send new values if they were updated.
   void loop() override;
 
@@ -76,10 +72,10 @@ class SM16716OutputComponent : public Component {
 
   GPIOPin *pin_data_;
   GPIOPin *pin_clock_;
-  uint8_t num_channels_;
-  uint8_t num_chips_;
+  uint8_t num_channels_{3};
+  uint8_t num_chips_{1};
   std::vector<uint8_t> pwm_amounts_;
-  bool update_;
+  bool update_{true};
 };
 
 }  // namespace output

--- a/src/esphome/output/sm16716_output_component.h
+++ b/src/esphome/output/sm16716_output_component.h
@@ -49,7 +49,7 @@ class SM16716OutputComponent : public Component {
   // (In most use cases you won't need these)
   uint8_t get_num_channels() const;
   uint8_t get_num_chips() const;
-  
+
   /// Setup the SM16716.
   void setup() override;
   void dump_config() override;

--- a/src/esphome/output/sm16716_output_component.h
+++ b/src/esphome/output/sm16716_output_component.h
@@ -39,18 +39,18 @@ class SM16716OutputComponent : public Component {
 
   /// Manually set the total number of channels. Defaults to 3.
   void set_num_channels(uint8_t num_channels);
-  
+
   /// Manually set the number of chips. Defaults to 1.
   void set_num_chips(uint8_t num_chips);
 
   /// Setup the SM16716.
   void setup() override;
-  
+
   void dump_config() override;
-  
+
   /// HARDWARE setup_priority
   float get_setup_priority() const override;
-  
+
   /// Send new values if they were updated.
   void loop() override;
 

--- a/src/esphome/output/sm16716_output_component.h
+++ b/src/esphome/output/sm16716_output_component.h
@@ -1,0 +1,92 @@
+#ifndef ESPHOME_OUTPUT_SM16716_OUTPUT_COMPONENT_H
+#define ESPHOME_OUTPUT_SM16716_OUTPUT_COMPONENT_H
+
+#include "esphome/defines.h"
+
+#ifdef USE_SM16716_OUTPUT
+
+#include "esphome/output/float_output.h"
+
+ESPHOME_NAMESPACE_BEGIN
+
+namespace output {
+
+/// SM16716 float output component.
+class SM16716OutputComponent : public Component {
+ public:
+  class Channel;
+  /** Construct the component.
+   *
+   * @param pin_mosi The pin which MOSI (master out slave in) is connected to.
+   * @param pin_sclk The pin which SCLK (serial clock) is connected to.
+   * @param num_channels Total number of channels of the whole daisy chain.
+   * @param num_chips Number of chips in the daisy chain.
+   * @param update Update/reset duty data at boot (driver will keep
+   *               configuration after powercycle)
+   */
+  SM16716OutputComponent(GPIOPin *pin_mosi, GPIOPin *pin_sclk,
+                         uint8_t num_channels = 3, uint8_t num_chips = 1,
+                         bool update = true);
+
+  /** Get a SM16716 output channel.
+   *
+   * @param channel The channel number. (0 is the closest channel)
+   * @param power_supply The power supply that should be set for this channel.
+   *                     Default: nullptr.
+   * @param max_power The maximum power output of this channel. Each value will
+   *                  be multiplied by this.
+   * @return The new channel output component.
+   */
+  Channel *create_channel(uint8_t channel, PowerSupplyComponent *power_supply = nullptr, float max_power = 1.0f);
+
+  /// Manually set the total number of channels. Defaults to 3.
+  void set_num_channels(uint8_t num_channels);
+  /// Manually set the number of chips. Defaults to 1.
+  void set_num_chips(uint8_t num_chips);
+  /// Manually set duty data update on boot. Defaults is true.
+  void set_update(bool update);
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  uint8_t get_num_channels() const;
+  uint8_t get_num_chips() const;
+  
+  /// Setup the SM16716.
+  void setup() override;
+  void dump_config() override;
+  /// HARDWARE setup_priority
+  float get_setup_priority() const override;
+  /// Send new values if they were updated.
+  void loop() override;
+
+  class Channel : public FloatOutput {
+   public:
+    Channel(SM16716OutputComponent *parent, uint8_t channel);
+
+   protected:
+    void write_state(float state) override;
+
+    SM16716OutputComponent *parent_;
+    uint8_t channel_;
+  };
+
+ protected:
+  void set_channel_value_(uint8_t channel, uint8_t value);
+  void write_bit_(bool);
+  void write_byte_(uint8_t);
+
+  GPIOPin *pin_mosi_;
+  GPIOPin *pin_sclk_;
+  uint8_t num_channels_;
+  uint8_t num_chips_;
+  std::vector<uint8_t> pwm_amounts_;
+  bool update_;
+};
+
+}  // namespace output
+
+ESPHOME_NAMESPACE_END
+
+#endif  // USE_SM16716_OUTPUT
+
+#endif  // ESPHOME_OUTPUT_SM16716_OUTPUT_COMPONENT_H

--- a/src/esphome/output/sm16716_output_component.h
+++ b/src/esphome/output/sm16716_output_component.h
@@ -17,14 +17,14 @@ class SM16716OutputComponent : public Component {
   class Channel;
   /** Construct the component.
    *
-   * @param pin_mosi The pin which MOSI (master out slave in) is connected to.
-   * @param pin_sclk The pin which SCLK (serial clock) is connected to.
+   * @param pin_data The data output pin, connected to the SM16716's DIN pin.
+   * @param pin_clock The clock pin, connected to the SM16716's DCLK pin.
    * @param num_channels Total number of channels of the whole daisy chain.
    * @param num_chips Number of chips in the daisy chain.
    * @param update Update/reset duty data at boot (driver will keep
    *               configuration after powercycle)
    */
-  SM16716OutputComponent(GPIOPin *pin_mosi, GPIOPin *pin_sclk, uint8_t num_channels = 3, uint8_t num_chips = 1,
+  SM16716OutputComponent(GPIOPin *pin_data, GPIOPin *pin_clock, uint8_t num_channels = 3, uint8_t num_chips = 1,
                          bool update = true);
 
   /** Get a SM16716 output channel.
@@ -74,8 +74,8 @@ class SM16716OutputComponent : public Component {
   void write_bit_(bool);
   void write_byte_(uint8_t);
 
-  GPIOPin *pin_mosi_;
-  GPIOPin *pin_sclk_;
+  GPIOPin *pin_data_;
+  GPIOPin *pin_clock_;
   uint8_t num_channels_;
   uint8_t num_chips_;
   std::vector<uint8_t> pwm_amounts_;

--- a/src/esphome/output/sm16716_output_component.h
+++ b/src/esphome/output/sm16716_output_component.h
@@ -24,8 +24,7 @@ class SM16716OutputComponent : public Component {
    * @param update Update/reset duty data at boot (driver will keep
    *               configuration after powercycle)
    */
-  SM16716OutputComponent(GPIOPin *pin_mosi, GPIOPin *pin_sclk,
-                         uint8_t num_channels = 3, uint8_t num_chips = 1,
+  SM16716OutputComponent(GPIOPin *pin_mosi, GPIOPin *pin_sclk, uint8_t num_channels = 3, uint8_t num_chips = 1,
                          bool update = true);
 
   /** Get a SM16716 output channel.


### PR DESCRIPTION
## Description:
This adds an output component for the SM16716 LED driver. I started with the existing MY9231 output component as a base and adjusted as needed. Hopefully that means the code is already pretty close to acceptable. :)

This chip is used in these bulbs (that I'm aware of):
* Feit Electric A19 Smart WiFi Bulb
* Merkury A21 75W color bulb

I only have the Feit Electric A19 to test with and it only as a single chip so I can't test using multiple chips for additional channels. 

I also haven't made the documentation changes yet. I'll try to get to those soon.

**Related issue (if applicable):** implements esphome/feature-requests#83

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#500
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#217

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
