### PR TITLE
Add support for IAQ calculation in BME680

### DIFF
--- a/examples/bme680-test/bme680-test.cpp
+++ b/examples/bme680-test/bme680-test.cpp
@@ -1,0 +1,21 @@
+#include <esphome.h>
+
+using namespace esphome;
+
+void setup() {
+  App.set_name("BME680 Test");
+  App.init_log();
+
+  App.init_wifi("YOUR_SSID", "YOUR_PASSWORD");
+  App.init_mqtt("MQTT_HOST", "USERNAME", "PASSWORD");
+  App.init_ota()->start_safe_mode();
+
+  App.init_i2c(21, 22, true);
+  App.make_bme680_sensor("BME680 Temperature", "BME680 Pressure", "BME680 Humidity", "BME680 Gas Resistance", "BME680 Air Quality");
+  
+  App.setup();
+}
+
+void loop() {
+  App.loop();
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -57,3 +57,11 @@ framework = arduino
 lib_deps = ${common.lib_deps}
 build_flags = ${common.build_flags}
 src_filter = ${common.src_filter} +<examples/fastled/fastled.cpp>
+
+[env:bme680-test]
+platform = espressif32@1.6.0
+board = nodemcu-32s
+framework = arduino
+lib_deps = ${common.lib_deps}
+build_flags = ${common.build_flags}
+src_filter = ${common.src_filter} +<examples/bme680-test/bme680-test.cpp>

--- a/src/esphome/application.cpp
+++ b/src/esphome/application.cpp
@@ -637,14 +637,16 @@ sensor::BMP280Component *Application::make_bmp280_sensor(const std::string &temp
 sensor::BME680Component *Application::make_bme680_sensor(const std::string &temperature_name,
                                                          const std::string &pressure_name,
                                                          const std::string &humidity_name,
-                                                         const std::string &gas_resistance_name, uint8_t address,
+                                                         const std::string &gas_resistance_name,
+                                                         const std::string &air_quality_name, uint8_t address,
                                                          uint32_t update_interval) {
   auto *bme680 = this->register_component(new BME680Component(
-      this->i2c_, temperature_name, pressure_name, humidity_name, gas_resistance_name, address, update_interval));
+      this->i2c_, temperature_name, pressure_name, humidity_name, gas_resistance_name, air_quality_name, address, update_interval));
   this->register_sensor(bme680->get_temperature_sensor());
   this->register_sensor(bme680->get_pressure_sensor());
   this->register_sensor(bme680->get_humidity_sensor());
   this->register_sensor(bme680->get_gas_resistance_sensor());
+  this->register_sensor(bme680->get_air_quality_sensor());
   return bme680;
 }
 #endif

--- a/src/esphome/application.h
+++ b/src/esphome/application.h
@@ -675,7 +675,8 @@ class Application {
 #ifdef USE_BME680
   sensor::BME680Component *make_bme680_sensor(const std::string &temperature_name, const std::string &pressure_name,
                                               const std::string &humidity_name, const std::string &gas_resistance_name,
-                                              uint8_t address = 0x76, uint32_t update_interval = 60000);
+                                              const std::string &air_quality_name, uint8_t address = 0x76, 
+                                              uint32_t update_interval = 60000);
 #endif
 
 #ifdef USE_SHT3XD

--- a/src/esphome/sensor/bme680_component.h
+++ b/src/esphome/sensor/bme680_component.h
@@ -72,18 +72,20 @@ struct BME680CalibrationData {
 
   float tfine;
   uint8_t ambient_temperature;
+  uint32_t gas_baseline;
 };
 
 using BME680TemperatureSensor = sensor::EmptyPollingParentSensor<1, ICON_EMPTY, UNIT_C>;
 using BME680PressureSensor = sensor::EmptyPollingParentSensor<1, ICON_GAUGE, UNIT_HPA>;
 using BME680HumiditySensor = sensor::EmptyPollingParentSensor<1, ICON_WATER_PERCENT, UNIT_PERCENT>;
 using BME680GasResistanceSensor = sensor::EmptyPollingParentSensor<1, ICON_GAS_CYLINDER, UNIT_OHM>;
+using BME680AirQualitySensor = sensor::EmptyPollingParentSensor<1, ICON_AIR_FILTER, UNIT_EMPTY>;
 
 class BME680Component : public PollingComponent, public I2CDevice {
  public:
   BME680Component(I2CComponent *parent, const std::string &temperature_name, const std::string &pressure_name,
-                  const std::string &humidity_name, const std::string &gas_resistance_name, uint8_t address = 0x76,
-                  uint32_t update_interval = 60000);
+                  const std::string &humidity_name, const std::string &gas_resistance_name, 
+                  const std::string &air_quality_name, uint8_t address = 0x76, uint32_t update_interval = 60000);
 
   /// Set the temperature oversampling value. Defaults to 16X.
   void set_temperature_oversampling(BME680Oversampling temperature_oversampling);
@@ -116,6 +118,7 @@ class BME680Component : public PollingComponent, public I2CDevice {
   BME680PressureSensor *get_pressure_sensor() const;
   BME680HumiditySensor *get_humidity_sensor() const;
   BME680GasResistanceSensor *get_gas_resistance_sensor() const;
+  BME680AirQualitySensor *get_air_quality_sensor() const;
 
  protected:
   /// Calculate the heater resistance value to send to the BME680 register.
@@ -135,6 +138,8 @@ class BME680Component : public PollingComponent, public I2CDevice {
   uint32_t calc_gas_resistance_(uint16_t raw_gas, uint8_t range);
   /// Calculate how long the sensor will take until we can retrieve data.
   uint32_t calc_meas_duration_();
+  // Calculate the Indoor Air Quality index.
+  float calc_air_quality_(uint32_t gas_resistance, float humidity);
 
   BME680CalibrationData calibration_;
   BME680Oversampling temperature_oversampling_{BME680_OVERSAMPLING_16X};
@@ -148,6 +153,7 @@ class BME680Component : public PollingComponent, public I2CDevice {
   BME680PressureSensor *pressure_sensor_;
   BME680HumiditySensor *humidity_sensor_;
   BME680GasResistanceSensor *gas_resistance_sensor_;
+  BME680AirQualitySensor *air_quality_sensor_;
 };
 
 }  // namespace sensor

--- a/src/esphome/sensor/sensor.cpp
+++ b/src/esphome/sensor/sensor.cpp
@@ -160,6 +160,8 @@ const char UNIT_K[] = "K";
 const char UNIT_MICROSIEMENS_PER_CENTIMETER[] = "µS/cm";
 const char UNIT_MICROGRAMS_PER_CUBIC_METER[] = "µg/m³";
 const char ICON_CHEMICAL_WEAPON[] = "mdi:chemical-weapon";
+const char ICON_AIR_FILTER[] = "mdi:air-filter";
+const char UNIT_EMPTY[] = "";
 
 SensorStateTrigger::SensorStateTrigger(Sensor *parent) {
   parent->add_on_state_callback([this](float value) { this->trigger(value); });

--- a/src/esphome/sensor/sensor.h
+++ b/src/esphome/sensor/sensor.h
@@ -330,6 +330,7 @@ extern const char ICON_LIGHTBULB[];
 extern const char ICON_BATTERY[];
 extern const char ICON_FLOWER[];
 extern const char ICON_CHEMICAL_WEAPON[];
+extern const char ICON_AIR_FILTER[];
 
 extern const char UNIT_C[];
 extern const char UNIT_PERCENT[];
@@ -347,6 +348,7 @@ extern const char UNIT_DEGREES[];
 extern const char UNIT_K[];
 extern const char UNIT_MICROSIEMENS_PER_CENTIMETER[];
 extern const char UNIT_MICROGRAMS_PER_CUBIC_METER[];
+extern const char UNIT_EMPTY[];
 
 template<typename... Ts> SensorInRangeCondition<Ts...> *Sensor::make_sensor_in_range_condition() {
   return new SensorInRangeCondition<Ts...>(this);


### PR DESCRIPTION
## Description:
This PR adds an indoor air quality sensor to the BME680 component. I feel this measure is more useful than the raw gas resistance.

## Checklist:

  - [x] The code change is tested and works locally.
  - [ ] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
