### PR TITLE
Make Climate component work over mqtt

### DIFF
--- a/src/esphome/climate/climate_automation.h
+++ b/src/esphome/climate/climate_automation.h
@@ -27,7 +27,8 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
 
   void play(Ts... x) override {
     auto call = this->climate_->make_call();
-    call.set_target_temperature(this->mode_.optional_value(x...));
+    call.set_mode(this->mode_.optional_value(x...));
+    call.set_target_temperature(this->target_temperature_.optional_value(x...));
     call.set_target_temperature_low(this->target_temperature_low_.optional_value(x...));
     call.set_target_temperature_high(this->target_temperature_high_.optional_value(x...));
     call.set_away(this->away_.optional_value(x...));

--- a/src/esphome/climate/climate_device.h
+++ b/src/esphome/climate/climate_device.h
@@ -176,7 +176,7 @@ class ClimateDevice : public Nameable {
    */
   ClimateTraits get_traits();
 
-#ifdef USE_MQTT_COVER
+#ifdef USE_MQTT_CLIMATE
   MQTTClimateComponent *get_mqtt() const;
   void set_mqtt(MQTTClimateComponent *mqtt);
 #endif

--- a/src/esphome/climate/climate_mode.cpp
+++ b/src/esphome/climate/climate_mode.cpp
@@ -11,13 +11,13 @@ namespace climate {
 const char *climate_mode_to_string(ClimateMode mode) {
   switch (mode) {
     case CLIMATE_MODE_OFF:
-      return "OFF";
+      return "off";
     case CLIMATE_MODE_AUTO:
-      return "AUTO";
+      return "auto";
     case CLIMATE_MODE_COOL:
-      return "COOL";
+      return "cool";
     case CLIMATE_MODE_HEAT:
-      return "HEAT";
+      return "heat";
     default:
       return "UNKNOWN";
   }

--- a/src/esphome/climate/mqtt_climate_component.cpp
+++ b/src/esphome/climate/mqtt_climate_component.cpp
@@ -26,12 +26,12 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
   JsonArray &modes = root.createNestedArray("modes");
   // sort array for nice UI in HA
   if (traits.supports_mode(CLIMATE_MODE_AUTO))
-    modes.add("auto");
-  modes.add("off");
+    modes.add(climate_mode_to_string(CLIMATE_MODE_AUTO));
+  modes.add(climate_mode_to_string(CLIMATE_MODE_OFF));
   if (traits.supports_mode(CLIMATE_MODE_COOL))
-    modes.add("cool");
+    modes.add(climate_mode_to_string(CLIMATE_MODE_COOL));
   if (traits.supports_mode(CLIMATE_MODE_HEAT))
-    modes.add("heat");
+    modes.add(climate_mode_to_string(CLIMATE_MODE_HEAT));
 
   if (traits.get_supports_two_point_target_temperature()) {
     // temperature_low_command_topic

--- a/src/esphome/climate/mqtt_climate_component.cpp
+++ b/src/esphome/climate/mqtt_climate_component.cpp
@@ -62,6 +62,8 @@ void MQTTClimateComponent::send_discovery(JsonObject &root, mqtt::SendDiscoveryC
     // away_mode_state_topic
     root["away_mode_state_topic"] = this->get_away_state_topic();
   }
+  config.state_topic = false;
+  config.command_topic = false;
 }
 void MQTTClimateComponent::setup() {
   auto traits = this->device_->get_traits();
@@ -146,7 +148,7 @@ bool MQTTClimateComponent::publish_state_() {
   if (!this->publish(this->get_mode_state_topic(), mode_s))
     success = false;
   int8_t accuracy = traits.get_temperature_accuracy_decimals();
-  if (traits.get_supports_current_temperature()) {
+  if (traits.get_supports_current_temperature() && !isnan(this->device_->current_temperature)) {
     std::string payload = value_accuracy_to_string(this->device_->current_temperature, accuracy);
     if (!this->publish(this->get_current_temperature_state_topic(), payload))
       success = false;


### PR DESCRIPTION
## Description:
HA require the same spelling case for mode (discovery and state).

The second commit is optional.

**Related issue (if applicable):** #574

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
