### PR TITLE
Remove high frequency mode from addressable light effects

### DIFF
--- a/src/esphome/light/addressable_light_effect.cpp
+++ b/src/esphome/light/addressable_light_effect.cpp
@@ -14,9 +14,7 @@ void AddressableLightEffect::start_internal() {
   this->start();
 }
 
-void AddressableLightEffect::stop() {
-  this->get_addressable_()->set_effect_active(false);
-}
+void AddressableLightEffect::stop() { this->get_addressable_()->set_effect_active(false); }
 
 AddressableLight *AddressableLightEffect::get_addressable_() const {
   return (AddressableLight *) this->state_->get_output();

--- a/src/esphome/light/addressable_light_effect.cpp
+++ b/src/esphome/light/addressable_light_effect.cpp
@@ -11,13 +11,11 @@ namespace light {
 void AddressableLightEffect::start_internal() {
   this->get_addressable_()->set_effect_active(true);
   this->get_addressable_()->clear_effect_data();
-  this->high_freq_.start();
   this->start();
 }
 
 void AddressableLightEffect::stop() {
   this->get_addressable_()->set_effect_active(false);
-  this->high_freq_.stop();
 }
 
 AddressableLight *AddressableLightEffect::get_addressable_() const {

--- a/src/esphome/light/addressable_light_effect.h
+++ b/src/esphome/light/addressable_light_effect.h
@@ -22,8 +22,6 @@ class AddressableLightEffect : public LightEffect {
 
  protected:
   AddressableLight *get_addressable_() const;
-
-  HighFrequencyLoopRequester high_freq_;
 };
 
 class AddressableLambdaLightEffect : public AddressableLightEffect {


### PR DESCRIPTION
## Description:
It appears to be unnecessary for fastLED, and it break effects for NeoPixelBus.

**Related issue (if applicable):** fixes esphome/issues#227

## Checklist:

  - [x] The code change is tested and works locally. (I have tested it both with fastled and neopixelbus)
  - [x] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)
