### PR TITLE
MH-Z19 sensor: disable auto-calibration and  some odd fixes

### DIFF
--- a/src/esphome/sensor/mhz19_component.cpp
+++ b/src/esphome/sensor/mhz19_component.cpp
@@ -38,6 +38,13 @@ void MHZ19Component::update() {
     return;
   }
 
+  /* Sensor reports U(15000) during boot, ingnore reported CO2 until it boots */
+  uint16_t u = (response[6] << 8) + response[7];
+  if (u == 15000) {
+    ESP_LOGD(TAG, "Sensor is booting");
+    return;
+  }
+
   uint8_t checksum = mhz19_checksum(response);
   if (response[8] != checksum) {
     ESP_LOGW(TAG, "MHZ19 Checksum doesn't match: 0x%02X!=0x%02X", response[8], checksum);

--- a/src/esphome/sensor/mhz19_component.cpp
+++ b/src/esphome/sensor/mhz19_component.cpp
@@ -13,6 +13,7 @@ static const char *TAG = "sensor.mhz19";
 static const uint8_t MHZ19_REQUEST_LENGTH = 8;
 static const uint8_t MHZ19_RESPONSE_LENGTH = 9;
 static const uint8_t MHZ19_COMMAND_GET_PPM[] = {0xFF, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00};
+static const uint8_t MHZ19_COMMAND_ABC_DISABLE[] = {0xFF, 0x01, 0x79, 0x00, 0x00, 0x00, 0x00, 0x00, 0x86};
 
 MHZ19Component::MHZ19Component(UARTComponent *parent, const std::string &co2_name, uint32_t update_interval)
     : PollingComponent(update_interval), UARTDevice(parent), co2_sensor_(new MHZ19CO2Sensor(co2_name, this)) {}
@@ -52,6 +53,24 @@ void MHZ19Component::update() {
     this->model_b = true;
   }
 
+  if (this->model_b && this->abc_disabled == false) {
+    uint8_t abc_ack[MHZ19_RESPONSE_LENGTH];
+    /*
+     * MH-Z19B allows to enable/disable 'automatic baseline calibration' (datasheet MH-Z19B v1.2),
+     * disable it to prevent sensor baseline drift in not well ventilated area
+     */
+    ESP_LOGI(TAG, "Disabling ABC on boot");
+    if (!this->mhz19_write_command_(MHZ19_COMMAND_ABC_DISABLE, abc_ack)) {
+      ESP_LOGW(TAG, "Failed to read ABC disable ack!");
+      return;
+    }
+    this->abc_disabled = true;
+    /*
+     * TODO: implement an option to recalibrate sensor, to allow for occasional
+     * manual recalibration
+     */
+  }
+
   uint8_t checksum = mhz19_checksum(response);
   if (response[8] != checksum) {
     ESP_LOGW(TAG, "MHZ19 Checksum doesn't match: 0x%02X!=0x%02X", response[8], checksum);
@@ -88,7 +107,7 @@ MHZ19TemperatureSensor *MHZ19Component::make_temperature_sensor(const std::strin
 MHZ19CO2Sensor *MHZ19Component::get_co2_sensor() const { return this->co2_sensor_; }
 float MHZ19Component::get_setup_priority() const { return setup_priority::HARDWARE_LATE; }
 void MHZ19Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "MH-Z19%s:", this->model_b ? "B:" : "");
+  ESP_LOGCONFIG(TAG, "MH-Z19%s%s", this->model_b ? "B:" : "", this->abc_disabled ? " (auto calibration: disabled)": " (auto calibration: enabled)");
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
 }

--- a/src/esphome/sensor/mhz19_component.cpp
+++ b/src/esphome/sensor/mhz19_component.cpp
@@ -45,6 +45,13 @@ void MHZ19Component::update() {
     return;
   }
 
+  /* MH-Z19B(s == 0) and MH-Z19(s != 0) */
+  uint8_t s = response[5];
+  if (response[5] == 0 && this->model_b == false) {
+    ESP_LOGD(TAG, "MH-Z19B detected");
+    this->model_b = true;
+  }
+
   uint8_t checksum = mhz19_checksum(response);
   if (response[8] != checksum) {
     ESP_LOGW(TAG, "MHZ19 Checksum doesn't match: 0x%02X!=0x%02X", response[8], checksum);
@@ -81,7 +88,7 @@ MHZ19TemperatureSensor *MHZ19Component::make_temperature_sensor(const std::strin
 MHZ19CO2Sensor *MHZ19Component::get_co2_sensor() const { return this->co2_sensor_; }
 float MHZ19Component::get_setup_priority() const { return setup_priority::HARDWARE_LATE; }
 void MHZ19Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "MH-Z19:");
+  ESP_LOGCONFIG(TAG, "MH-Z19%s:", this->model_b ? "B:" : "");
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
 }

--- a/src/esphome/sensor/mhz19_component.h
+++ b/src/esphome/sensor/mhz19_component.h
@@ -35,6 +35,7 @@ class MHZ19Component : public PollingComponent, public UARTDevice {
   MHZ19CO2Sensor *co2_sensor_;
   bool model_b;
   bool abc_disabled;
+  int cleanup_rx_buffer;
 };
 
 }  // namespace sensor

--- a/src/esphome/sensor/mhz19_component.h
+++ b/src/esphome/sensor/mhz19_component.h
@@ -34,6 +34,7 @@ class MHZ19Component : public PollingComponent, public UARTDevice {
   MHZ19TemperatureSensor *temperature_sensor_{nullptr};
   MHZ19CO2Sensor *co2_sensor_;
   bool model_b;
+  bool abc_disabled;
 };
 
 }  // namespace sensor

--- a/src/esphome/sensor/mhz19_component.h
+++ b/src/esphome/sensor/mhz19_component.h
@@ -33,6 +33,7 @@ class MHZ19Component : public PollingComponent, public UARTDevice {
 
   MHZ19TemperatureSensor *temperature_sensor_{nullptr};
   MHZ19CO2Sensor *co2_sensor_;
+  bool model_b;
 };
 
 }  // namespace sensor


### PR DESCRIPTION
## Description:
* Adds detection of MH-Z19B sensor
* Ignore sensor reported values until it's booted.
* Disable auto-calibration as it makes reported CO2 values not reflecting real situation in not sufficiently ventilated environment.
* Fix/workaround non-recoverable "Invalid preamble from MHZ19!" case, when sensor is connected to hardware UART.

## Checklist:

  - [x] The code change is tested and works locally.
  - [ x] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
