### PR TITLE
Add cat9554

### DIFF
--- a/src/esphome/application.cpp
+++ b/src/esphome/application.cpp
@@ -575,6 +575,12 @@ PCF8574Component *Application::make_pcf8574_component(uint8_t address, bool pcf8
 }
 #endif
 
+#ifdef USE_CAT9554
+CAT9554Component *Application::make_cat9554_component(uint8_t address, uint8_t irq) {
+  return this->register_component(new CAT9554Component(this->i2c_, address, irq));
+}
+#endif
+
 #ifdef USE_MPU6050
 sensor::MPU6050Component *Application::make_mpu6050_sensor(uint8_t address, uint32_t update_interval) {
   return this->register_component(new MPU6050Component(this->i2c_, address, update_interval));

--- a/src/esphome/application.h
+++ b/src/esphome/application.h
@@ -53,6 +53,7 @@
 #include "esphome/fan/mqtt_fan_component.h"
 #include "esphome/io/mcp23017.h"
 #include "esphome/io/pcf8574_component.h"
+#include "esphome/io/cat9554.h"
 #include "esphome/light/addressable_light_effect.h"
 #include "esphome/light/fast_led_light_output.h"
 #include "esphome/light/light_color_values.h"
@@ -1128,6 +1129,10 @@ class Application {
    * @return The PCF8574Component instance to get individual pins.
    */
   io::PCF8574Component *make_pcf8574_component(uint8_t address = 0x21, bool pcf8575 = false);
+#endif
+
+#ifdef USE_CAT9554
+  io::CAT9554Component *make_cat9554_component(uint8_t address, uint8_t irq);
 #endif
 
 #ifdef USE_MCP23017

--- a/src/esphome/defines.h
+++ b/src/esphome/defines.h
@@ -57,6 +57,7 @@
 #define USE_DEBUG_COMPONENT
 #define USE_DEEP_SLEEP
 #define USE_PCF8574
+#define USE_CAT9554
 #define USE_MCP23017
 #define USE_IO
 #define USE_SDS011
@@ -192,6 +193,11 @@
 #endif
 #endif
 #ifdef USE_PCF8574
+#ifndef USE_IO
+#define USE_IO
+#endif
+#endif
+#ifdef USE_CAT9554
 #ifndef USE_IO
 #define USE_IO
 #endif

--- a/src/esphome/io/cat9554.cpp
+++ b/src/esphome/io/cat9554.cpp
@@ -139,8 +139,8 @@ bool CAT9554Component::read_config_() {
   this->status_clear_warning();
   return true;
 }
-CAT9554GPIOInputPin CAT9554Component::make_input_pin(uint8_t pin, bool inverted) {
-  return {this, pin, CAT9554_INPUT, inverted};
+CAT9554GPIOInputPin CAT9554Component::make_input_pin(uint8_t pin, uint8_t mode, bool inverted) {
+  return {this, pin, mode, inverted};
 }
 CAT9554GPIOOutputPin CAT9554Component::make_output_pin(uint8_t pin, bool inverted) {
   return {this, pin, CAT9554_OUTPUT, inverted};

--- a/src/esphome/io/cat9554.cpp
+++ b/src/esphome/io/cat9554.cpp
@@ -1,0 +1,174 @@
+// Based on:
+//   - https://www.onsemi.com/pub/Collateral/CAT9554-D.PDF
+
+#include "esphome/defines.h"
+
+#ifdef USE_CAT9554
+
+#include "esphome/io/cat9554.h"
+#include "esphome/log.h"
+
+ESPHOME_NAMESPACE_BEGIN
+
+namespace io {
+
+static const char *TAG = "io.cat9554";
+
+static CAT9554Component *instance_;
+static void ICACHE_RAM_ATTR HOT gpio_intr(CAT9554Component **instance) {
+  (*instance)->update_gpio_needed(true);
+}
+
+CAT9554Component::CAT9554Component(I2CComponent *parent, uint8_t address, uint8_t irq)
+    : Component(), I2CDevice(parent, address), irq_(irq) {}
+
+void CAT9554Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up CAT9554...");
+  ESP_LOGCONFIG(TAG, "    Address: 0x%02X", this->address_);
+  if (!this->read_gpio_()) {
+    ESP_LOGE(TAG, "CAT9554 not available under 0x%02X", this->address_);
+    this->mark_failed();
+    return;
+  }
+
+  instance_ = this;
+  this->pin_ = new GPIOInputPin(this->irq_);
+  this->pin_->setup();
+  this->isr_ = this->pin_->to_isr();
+  this->pin_->attach_interrupt(gpio_intr, &instance_, FALLING);
+  //this->write_gpio_();
+  this->read_gpio_();
+  this->read_config_();
+  this->update_gpio_ = false;
+}
+
+void CAT9554Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "CAT9554:");
+  ESP_LOGCONFIG(TAG, "    Address: 0x%02X", this->address_);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with CAT9554 failed!");
+  }
+}
+bool CAT9554Component::digital_read(uint8_t pin) {
+  if (this->update_gpio_) {
+    this->read_gpio_();
+    this->update_gpio_ = false;
+  }
+  return this->input_mask_ & (1 << pin);
+}
+void CAT9554Component::digital_write(uint8_t pin, bool value) {
+  if (value) {
+    this->output_mask_ |= (1 << pin);
+  } else {
+    this->output_mask_ &= ~(1 << pin);
+  }
+
+  this->write_gpio_();
+}
+void CAT9554Component::pin_mode(uint8_t pin, uint8_t mode) {
+  switch (mode) {
+    case CAT9554_INPUT:
+      this->config_mask_ |= (1 << pin);
+      break;
+    case CAT9554_OUTPUT:
+      this->config_mask_ &= ~(1 << pin);
+      break;
+    default:
+      break;
+  }
+
+  this->config_gpio_();
+}
+bool CAT9554Component::read_gpio_() {
+  if (this->is_failed())
+    return false;
+
+    uint8_t data;
+    if (!this->parent_->read_byte(this->address_, INPUT_REG & 0xff, &data, 1)) {
+      this->status_set_warning();
+      return false;
+    }
+    this->input_mask_ = data;
+
+  this->status_clear_warning();
+  return true;
+}
+bool CAT9554Component::write_gpio_() {
+  if (this->is_failed())
+    return false;
+
+  if (!this->parent_->write_byte(this->address_, OUTPUT & 0xff, this->output_mask_)) {
+    this->status_set_warning();
+    return false;
+  }
+
+  this->status_clear_warning();
+  return true;
+}
+bool CAT9554Component::config_gpio_() {
+  if (this->is_failed())
+    return false;
+
+  if (!this->parent_->write_byte(this->address_, INPUT_REG & 0xff, this->config_mask_)) {
+    this->status_set_warning();
+    return false;
+  }
+  if (!this->parent_->write_byte(this->address_, CONFIG_REG & 0xff, this->config_mask_)) {
+    this->status_set_warning();
+    return false;
+  }
+  if (!this->parent_->write_byte(this->address_, INPUT_REG & 0xff, 0x00)) {
+    this->status_set_warning();
+    return false;
+  }
+
+  this->status_clear_warning();
+  return true;
+}
+bool CAT9554Component::read_config_() {
+  if (this->is_failed())
+    return false;
+
+    uint8_t data;
+    if (!this->parent_->read_byte(this->address_, CONFIG_REG & 0xff, &data, 1)) {
+      this->status_set_warning();
+      return false;
+    }
+    this->config_mask_ = data;
+
+  this->status_clear_warning();
+  return true;
+}
+CAT9554GPIOInputPin CAT9554Component::make_input_pin(uint8_t pin, bool inverted) {
+  return {this, pin, CAT9554_INPUT, inverted};
+}
+CAT9554GPIOOutputPin CAT9554Component::make_output_pin(uint8_t pin, bool inverted) {
+  return {this, pin, CAT9554_OUTPUT, inverted};
+}
+float CAT9554Component::get_setup_priority() const { return setup_priority::HARDWARE; }
+
+void CAT9554GPIOInputPin::setup() { this->pin_mode(this->mode_); }
+bool CAT9554GPIOInputPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
+void CAT9554GPIOInputPin::digital_write(bool value) {
+  this->parent_->digital_write(this->pin_, value != this->inverted_);
+}
+CAT9554GPIOInputPin::CAT9554GPIOInputPin(CAT9554Component *parent, uint8_t pin, uint8_t mode, bool inverted)
+    : GPIOInputPin(pin, mode, inverted), parent_(parent) {}
+GPIOPin *CAT9554GPIOInputPin::copy() const { return new CAT9554GPIOInputPin(*this); }
+void CAT9554GPIOInputPin::pin_mode(uint8_t mode) { this->parent_->pin_mode(this->pin_, mode); }
+
+void CAT9554GPIOOutputPin::setup() { this->pin_mode(this->mode_); }
+bool CAT9554GPIOOutputPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
+void CAT9554GPIOOutputPin::digital_write(bool value) {
+  this->parent_->digital_write(this->pin_, value != this->inverted_);
+}
+CAT9554GPIOOutputPin::CAT9554GPIOOutputPin(CAT9554Component *parent, uint8_t pin, uint8_t mode, bool inverted)
+    : GPIOOutputPin(pin, mode, inverted), parent_(parent) {}
+GPIOPin *CAT9554GPIOOutputPin::copy() const { return new CAT9554GPIOOutputPin(*this); }
+void CAT9554GPIOOutputPin::pin_mode(uint8_t mode) { this->parent_->pin_mode(this->pin_, mode); }
+
+}  // namespace io
+
+ESPHOME_NAMESPACE_END
+
+#endif  // USE_CAT9554

--- a/src/esphome/io/cat9554.h
+++ b/src/esphome/io/cat9554.h
@@ -15,6 +15,7 @@ namespace io {
 
 enum CAT9554GPIOMode {
   CAT9554_INPUT = INPUT,
+  CAT9554_INPUT_PULLUP = INPUT_PULLUP,
   CAT9554_OUTPUT = OUTPUT,
 };
 
@@ -31,7 +32,7 @@ class CAT9554Component : public Component, public I2CDevice {
  public:
   CAT9554Component(I2CComponent *parent, uint8_t address, uint8_t irq);
 
-  CAT9554GPIOInputPin make_input_pin(uint8_t pin, bool inverted = false);
+  CAT9554GPIOInputPin make_input_pin(uint8_t pin, uint8_t mode = CAT9554_INPUT, bool inverted = false);
 
   CAT9554GPIOOutputPin make_output_pin(uint8_t pin, bool inverted = false);
 

--- a/src/esphome/io/cat9554.h
+++ b/src/esphome/io/cat9554.h
@@ -1,0 +1,108 @@
+#ifndef ESPHOME_CAT9554_H
+#define ESPHOME_CAT9554_H
+
+#include "esphome/defines.h"
+
+#ifdef USE_CAT9554
+
+#include "esphome/component.h"
+#include "esphome/esphal.h"
+#include "esphome/i2c_component.h"
+
+ESPHOME_NAMESPACE_BEGIN
+
+namespace io {
+
+enum CAT9554GPIOMode {
+  CAT9554_INPUT = INPUT,
+  CAT9554_OUTPUT = OUTPUT,
+};
+
+enum CAT9554Commands {
+  INPUT_REG = 0x00,
+  OUTPUT_REG = 0x01,
+  CONFIG_REG = 0x03,
+};
+
+class CAT9554GPIOInputPin;
+class CAT9554GPIOOutputPin;
+
+class CAT9554Component : public Component, public I2CDevice {
+ public:
+  CAT9554Component(I2CComponent *parent, uint8_t address, uint8_t irq);
+
+  CAT9554GPIOInputPin make_input_pin(uint8_t pin, bool inverted = false);
+
+  CAT9554GPIOOutputPin make_output_pin(uint8_t pin, bool inverted = false);
+
+  // ========== INTERNAL METHODS ==========
+  // (In most use cases you won't need these)
+  /// Check i2c availability and setup masks
+  void setup() override;
+  /// Helper function to read the value of a pin.
+  bool digital_read(uint8_t pin);
+  /// Helper function to write the value of a pin.
+  void digital_write(uint8_t pin, bool value);
+  /// Helper function to set the pin mode of a pin.
+  void pin_mode(uint8_t pin, uint8_t mode);
+
+  void update_gpio_needed(bool needed) {
+    this->update_gpio_ = needed;
+  };
+
+  float get_setup_priority() const override;
+
+  void dump_config() override;
+
+ protected:
+  uint8_t irq_;
+  GPIOInputPin *pin_;
+  ISRInternalGPIOPin *isr_;
+  bool update_gpio_;
+  bool read_gpio_();
+  bool write_gpio_();
+  bool config_gpio_();
+  bool read_config_();
+
+  uint8_t input_mask_{0x00};
+  uint8_t output_mask_{0x00};
+  uint8_t config_mask_{0x00};
+};
+
+class CAT9554GPIOInputPin : public GPIOInputPin {
+ public:
+  CAT9554GPIOInputPin(CAT9554Component *parent, uint8_t pin, uint8_t mode, bool inverted = false);
+
+  GPIOPin *copy() const override;
+
+  void setup() override;
+  void pin_mode(uint8_t mode) override;
+  bool digital_read() override;
+  void digital_write(bool value) override;
+
+ protected:
+  CAT9554Component *parent_;
+};
+
+class CAT9554GPIOOutputPin : public GPIOOutputPin {
+ public:
+  CAT9554GPIOOutputPin(CAT9554Component *parent, uint8_t pin, uint8_t mode, bool inverted = false);
+
+  GPIOPin *copy() const override;
+
+  void setup() override;
+  void pin_mode(uint8_t mode) override;
+  bool digital_read() override;
+  void digital_write(bool value) override;
+
+ protected:
+  CAT9554Component *parent_;
+};
+
+}  // namespace io
+
+ESPHOME_NAMESPACE_END
+
+#endif  // USE_CAT9554
+
+#endif  // ESPHOME_CAT9554_H


### PR DESCRIPTION
Signed-off-by: SchumyHao <schumyhaojl@126.com>

## Description:
Add IO extention IC [cat9554](https://www.onsemi.cn/pub/Collateral/CAT9554A-D.PDF) support.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with python changes (if applicable):** esphome/esphome#<esphome PR number goes here>
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] The code change follows the [standards](https://esphome.io/guides/contributing.html#contributing-to-esphome-core)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
